### PR TITLE
Permit `addressspace` qualifiers on arguments to main function

### DIFF
--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -8235,6 +8235,8 @@ void Sema::CheckMain(FunctionDecl* FD, const DeclSpec& DS) {
           Context.hasSameType(QualType(qs.strip(PT->getPointeeType()), 0),
                               Context.CharTy)) {
         qs.removeConst();
+        if (Context.getDefaultAS() == qs.getAddressSpace())
+          qs.removeAddressSpace();
         mismatch = !qs.empty();
       }
     }

--- a/test/CodeGen/cheri_main.c
+++ b/test/CodeGen/cheri_main.c
@@ -1,0 +1,38 @@
+// RUN: %clang -DNO_ARGS=1 -target cheri-unknown-freebsd %s -o - -emit-llvm -S | FileCheck %s
+// RUN: %clang -DPTR_PTR=1 -target cheri-unknown-freebsd %s -o - -emit-llvm -S | FileCheck %s
+// RUN: %clang -DCONST_PTR_PTR=1 -target cheri-unknown-freebsd %s -o - -emit-llvm -S | FileCheck %s
+// RUN: %clang -DARR_PTR=1 -target cheri-unknown-freebsd %s -o - -emit-llvm -S | FileCheck %s
+// RUN: %clang -DCONST_ARR_PTR=1 -target cheri-unknown-freebsd %s -o - -emit-llvm -S | FileCheck %s
+// CHECK: main
+
+// Ensure various legal main function protoypes are accepted.
+
+#ifdef NO_ARGS
+int main() {
+  return 0;
+}
+#endif
+
+#ifdef PTR_PTR
+int main(int argc, char **argv) {
+  return 0;
+}
+#endif
+
+#ifdef CONST_PTR_PTR
+int main(int argc, const char * const *argv) {
+  return 0;
+}
+#endif
+
+#ifdef ARR_PTR
+int main(int argc, char* argv[]) {
+  return 0;
+}
+#endif
+
+#ifdef CONST_ARR_PTR
+int main(int argc, const char* argv[]) {
+  return 0;
+}
+#endif


### PR DESCRIPTION
In sandbox mode, the addressspace(200) qualifier on the char** argument to main would cause the type checker to complain needlessly.
This causes SemaDecl to ignore addressspace qualifiers when checking the validity of main function arguments.

Should we avoid this check only when targeting CHERI sandbox mode, or is avoiding it all the time, as the commit currently does, preferable?

(Fixes #7)