### PR TITLE
Add a warning when casting from capability to pointer (and make C++ implicit capability conversions work like they do in C)

### DIFF
--- a/include/clang/AST/Expr.h
+++ b/include/clang/AST/Expr.h
@@ -847,6 +847,12 @@ public:
     return skipRValueSubobjectAdjustments(CommaLHSs, Adjustments);
   }
 
+  /// XXXAR: Expr->getType() returns int for the initializers expression in
+  /// `void x(int& __capability arg) { int& a = arg }`
+  /// DeclRefExpr 0x7ffb54000590 'int' lvalue ParmVar 0x7ffb53873eb8 'arg' 'int & __capability'
+  /// We need to also check the underlying type and return that
+  QualType getRealReferenceType() const;
+
   static bool classof(const Stmt *T) {
     return T->getStmtClass() >= firstExprConstant &&
            T->getStmtClass() <= lastExprConstant;

--- a/include/clang/AST/Type.h
+++ b/include/clang/AST/Type.h
@@ -3906,6 +3906,7 @@ public:
     attr_objc_kindof,
     attr_objc_inert_unsafe_unretained,
     attr_cheri_capability,
+    attr_memory_address,
   };
 
 private:

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1622,7 +1622,7 @@ def CHERICapability : TypeAttr {
   let Documentation = [Undocumented];
 }
 def MemoryAddress : TypeAttr {
-  let Spellings = [GNU<"memory_address">];
+  let Spellings = [GNU<"memory_address">, CXX11<"cheri","memory_address">];
   let Documentation = [Undocumented];
 }
 

--- a/include/clang/Basic/Attr.td
+++ b/include/clang/Basic/Attr.td
@@ -1621,6 +1621,10 @@ def CHERICapability : TypeAttr {
   let Spellings = [GNU<"cheri_capability">];
   let Documentation = [Undocumented];
 }
+def MemoryAddress : TypeAttr {
+  let Spellings = [GNU<"memory_address">];
+  let Documentation = [Undocumented];
+}
 
 def PointerInterpretationCaps : InheritableAttr {
   let Spellings = [GNU<"pointer_interpretation_capabilities">];

--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -71,7 +71,8 @@ def BuiltinMacroRedefined : DiagGroup<"builtin-macro-redefined">;
 def BuiltinRequiresHeader : DiagGroup<"builtin-requires-header">;
 
 def CHERICapabilityToIntegerCast : DiagGroup<"capability-to-integer-cast">;
-def CHERICaps : DiagGroup<"cheri-capability-misuse", [CHERICapabilityToIntegerCast]>;
+def CHERIPedantic : DiagGroup<"cheri-pedantic", [CHERICapabilityToIntegerCast]>;
+def CHERICaps : DiagGroup<"cheri-capability-misuse">;
 def MIPSCHERIPrototypes: DiagGroup<"mips-cheri-prototypes">;
 def MIPSCHERIBugs: DiagGroup<"mips-cheri-bugs">;
 

--- a/include/clang/Basic/DiagnosticGroups.td
+++ b/include/clang/Basic/DiagnosticGroups.td
@@ -69,9 +69,12 @@ def ObjCLiteralConversion : DiagGroup<"objc-literal-conversion">;
 def MacroRedefined : DiagGroup<"macro-redefined">;
 def BuiltinMacroRedefined : DiagGroup<"builtin-macro-redefined">;
 def BuiltinRequiresHeader : DiagGroup<"builtin-requires-header">;
-def CHERICaps : DiagGroup<"cheri-capability-misuse">;
+
+def CHERICapabilityToIntegerCast : DiagGroup<"capability-to-integer-cast">;
+def CHERICaps : DiagGroup<"cheri-capability-misuse", [CHERICapabilityToIntegerCast]>;
 def MIPSCHERIPrototypes: DiagGroup<"mips-cheri-prototypes">;
 def MIPSCHERIBugs: DiagGroup<"mips-cheri-bugs">;
+
 def C99Compat : DiagGroup<"c99-compat">;
 def CXXCompat: DiagGroup<"c++-compat">;
 def ExternCCompat : DiagGroup<"extern-c-compat">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5902,6 +5902,9 @@ def warn_capability_integer_cast : Warning<
   // XXXAR: this is currently too noisy when building CHERIBSD, have if off for now
   // InGroup<CHERICapabilityToIntegerCast>;
   InGroup<CHERICapabilityToIntegerCast>, DefaultIgnore;
+def warn_capability_pointer_cast : Warning<
+  "cast from capability type %0 to integer pointer type %1 is most likely an error">,
+  InGroup<CHERICaps>, DefaultError;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
 def note_use_cheri_cast : Note<
@@ -5918,7 +5921,7 @@ def warn_cheri_cast_noop : Warning<
   "__cheri_cast from %0 to %1 is a noop">,
 // XXXAR: not sure how to add a new CHERIPedantic group
 //  InGroup<CHERIPedantic>;
-  InGroup<Pedantic>;
+  InGroup<Pedantic>, DefaultIgnore;
 
 def warn_mixed_sign_comparison : Warning<
   "comparison of integers of different signs: %0 and %1">,

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5907,6 +5907,11 @@ def err_cheri_cast_invalid_target_type: Error<
 def err_cheri_cast_invalid_source_type: Error<
   "invalid source type %0 for __cheri_cast: source must be a capability or "
   "a pointer">;
+// TODO: make this a pedantic warning?
+def warn_cheri_cast_noop : Warning<
+  "__cheri_cast from %0 to %1 is a noop">,
+  InGroup<CHERICapabilityToIntegerCast>;
+
 def warn_mixed_sign_comparison : Warning<
   "comparison of integers of different signs: %0 and %1">,
   InGroup<SignCompare>, DefaultIgnore;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6236,6 +6236,9 @@ def err_bad_cxx_cast_bitfield : Error<
 def err_bad_cxx_cast_qualifiers_away : Error<
   "%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|"
   "functional-style cast}0 from %1 to %2 casts away qualifiers">;
+def err_bad_cxx_reference_cast_capability_qualifier : Error<
+"%select{const_cast|static_cast|reinterpret_cast|dynamic_cast|C-style cast|"
+"functional-style cast}0 to reference type %2 changes __capability qualifier">;
 def err_bad_const_cast_dest : Error<
   "%select{const_cast||||C-style cast|functional-style cast}0 to %2, "
   "which is not a reference, pointer-to-object, or pointer-to-data-member">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5897,8 +5897,8 @@ def warn_capability_integer_cast : Warning<
   InGroup<CHERICapabilityToIntegerCast>;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
-def note_insert_vaddr_or_intptr_fixit : Note<
-  "insert cast to vaddr_t or intptr_t to silence this warning">;
+def note_use_cheri_cast : Note<
+  "use __cheri_cast to convert between pointers and capabilities">;
 def err_cheri_cast_unrelated_type : Error<
   "invalid __cheri_cast from %0 to unrelated type %1">;
 def err_cheri_cast_invalid_target_type: Error<

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5899,6 +5899,14 @@ def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
 def note_insert_vaddr_or_intptr_fixit : Note<
   "insert cast to vaddr_t or intptr_t to silence this warning">;
+def err_cheri_cast_unrelated_type : Error<
+  "invalid __cheri_cast from %0 to unrelated type %1">;
+def err_cheri_cast_invalid_target_type: Error<
+  "invalid target type %0 for __cheri_cast: target must be a capability or "
+  "a pointer">;
+def err_cheri_cast_invalid_source_type: Error<
+  "invalid source type %0 for __cheri_cast: source must be a capability or "
+  "a pointer">;
 def warn_mixed_sign_comparison : Warning<
   "comparison of integers of different signs: %0 and %1">,
   InGroup<SignCompare>, DefaultIgnore;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5870,6 +5870,11 @@ def note_typecheck_assign_const : Note<
   "%select{non-|}1static data member %2 declared const here|"
   "member function %q1 is declared const here}0">;
 
+def err_typecheck_convert_cap_to_ptr: Error<"converting capability type %0 to "
+  "pointer type %1 without an explicit cast; if this is intended use __cheri_cast">;
+def err_typecheck_convert_ptr_to_cap: Error<"converting pointer type %0 to "
+  "capability type %1 without an explicit cast; if this is intended use __cheri_cast">;
+
 def warn_mixed_capability_binop : Warning<
   "binary expression on capability and non-capability types: %0 and %1.  "
   "Provenance will be inherited from left-hand side">,

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3186,6 +3186,10 @@ def warn_cast_align : Warning<
   InGroup<CastAlign>, DefaultIgnore;
 def err_cheri_cast_align : Error<
   "cast from %0 to %1 increases required alignment from %2 to %3">;
+// creating the right fixit replacement string is non-trivial, add a note instead
+def note_cheri_cast_align_fixit : Note<
+  "use __builtin_assume_aligned(..., sizeof(void* __capability)) if you know "
+  "that the source type is sufficiently aligned">;
 def warn_old_style_cast : Warning<
   "use of old-style cast">, InGroup<OldStyleCast>, DefaultIgnore;
 

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5899,11 +5899,9 @@ def warn_capability_no_provenance : Warning<
   InGroup<CHERICaps>;
 def warn_capability_integer_cast : Warning<
   "cast from capability type %0 to non-capability, non-address type %1 is most likely an error">,
-// XXXAR: this is currently too noisy when building CHERIBSD, have if off for now
-//  InGroup<CHERICapabilityToIntegerCast>;
-// XXXAR: not sure how to add a new CHERIPedantic group
-//  InGroup<CHERIPedantic>;
-  InGroup<Pedantic>;
+  // XXXAR: this is currently too noisy when building CHERIBSD, have if off for now
+  // InGroup<CHERICapabilityToIntegerCast>;
+  InGroup<CHERICapabilityToIntegerCast>, DefaultIgnore;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
 def note_use_cheri_cast : Note<

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5899,7 +5899,11 @@ def warn_capability_no_provenance : Warning<
   InGroup<CHERICaps>;
 def warn_capability_integer_cast : Warning<
   "cast from capability type %0 to non-capability, non-address type %1 is most likely an error">,
-  InGroup<CHERICapabilityToIntegerCast>;
+// XXXAR: this is currently too noisy when building CHERIBSD, have if off for now
+//  InGroup<CHERICapabilityToIntegerCast>;
+// XXXAR: not sure how to add a new CHERIPedantic group
+//  InGroup<CHERIPedantic>;
+  InGroup<Pedantic>;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
 def note_use_cheri_cast : Note<
@@ -5912,10 +5916,11 @@ def err_cheri_cast_invalid_target_type: Error<
 def err_cheri_cast_invalid_source_type: Error<
   "invalid source type %0 for __cheri_cast: source must be a capability or "
   "a pointer">;
-// TODO: make this a pedantic warning?
 def warn_cheri_cast_noop : Warning<
   "__cheri_cast from %0 to %1 is a noop">,
-  InGroup<CHERICapabilityToIntegerCast>;
+// XXXAR: not sure how to add a new CHERIPedantic group
+//  InGroup<CHERIPedantic>;
+  InGroup<Pedantic>;
 
 def warn_mixed_sign_comparison : Warning<
   "comparison of integers of different signs: %0 and %1">,

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2454,8 +2454,8 @@ def err_attribute_integers_only : Error<
   "%0 attribute argument may only refer to a function parameter of integer "
   "type">;
 def err_attribute_address_integers_only : Error<
-  "%0 attribute only applies to integer types that can store memory "
-  "addresses (%1 is invalid)">;
+  "%0 attribute only applies to integer types that can store addresses "
+  "(%1 is invalid)">;
 def warn_attribute_return_pointers_only : Warning<
   "%0 attribute only applies to return values that are pointers">,
   InGroup<IgnoredAttributes>;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5870,10 +5870,12 @@ def note_typecheck_assign_const : Note<
   "%select{non-|}1static data member %2 declared const here|"
   "member function %q1 is declared const here}0">;
 
-def err_typecheck_convert_cap_to_ptr: Error<"converting capability type %0 to "
-  "pointer type %1 without an explicit cast; if this is intended use __cheri_cast">;
-def err_typecheck_convert_ptr_to_cap: Error<"converting pointer type %0 to "
-  "capability type %1 without an explicit cast; if this is intended use __cheri_cast">;
+def err_typecheck_convert_cap_to_ptr: Error<"converting capability"
+  "%select{| reference to}2 type %0 to non-capability type %1 without "
+  "an explicit cast; if this is intended use __cheri_cast">;
+def err_typecheck_convert_ptr_to_cap: Error<"converting non-capability"
+  "%select{| reference to}2 type %0 to capability type %1 without "
+  "an explicit cast; if this is intended use __cheri_cast">;
 
 def warn_mixed_capability_binop : Warning<
   "binary expression on capability and non-capability types: %0 and %1.  "
@@ -5903,7 +5905,7 @@ def warn_capability_integer_cast : Warning<
   // InGroup<CHERICapabilityToIntegerCast>;
   InGroup<CHERICapabilityToIntegerCast>, DefaultIgnore;
 def warn_capability_pointer_cast : Warning<
-  "cast from capability type %0 to integer pointer type %1 is most likely an error">,
+  "cast from capability type %0 to non-capability type %1 is most likely an error">,
   InGroup<CHERICaps>, DefaultError;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1206,8 +1206,8 @@ def warn_multiple_selectors: Warning<
 
 def err_objc_kindof_nonobject : Error<
   "'__kindof' specifier cannot be applied to non-object type %0">;
-def err_objc_kindof_wrong_position : Error<
-  "'__kindof' type specifier must precede the declarator">;
+def err_attr_wrong_position : Error<
+  "'%0' type specifier must precede the declarator">;
 
 def err_objc_method_unsupported_param_ret_type : Error<
   "%0 %select{parameter|return}1 type is unsupported; "
@@ -2453,6 +2453,9 @@ def err_attribute_pointers_only : Error<warn_attribute_pointers_only.Text>;
 def err_attribute_integers_only : Error<
   "%0 attribute argument may only refer to a function parameter of integer "
   "type">;
+def err_attribute_address_integers_only : Error<
+  "%0 attribute only applies to integer types that can store memory "
+  "addresses (%1 is invalid)">;
 def warn_attribute_return_pointers_only : Warning<
   "%0 attribute only applies to return values that are pointers">,
   InGroup<IgnoredAttributes>;
@@ -5889,8 +5892,13 @@ def warn_capability_no_provenance : Warning<
   "cast from provenance-free integer type to pointer type will give pointer"
   " that can not be dereferenced.  ">,
   InGroup<CHERICaps>;
+def warn_capability_integer_cast : Warning<
+  "cast from capability type %0 to non-capability, non-address type %1 is most likely an error">,
+  InGroup<CHERICapabilityToIntegerCast>;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
+def note_insert_vaddr_or_intptr_fixit : Note<
+  "insert cast to vaddr_t or intptr_t to silence this warning">;
 def warn_mixed_sign_comparison : Warning<
   "comparison of integers of different signs: %0 and %1">,
   InGroup<SignCompare>, DefaultIgnore;

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -5909,12 +5909,11 @@ def warn_capability_integer_cast : Warning<
   // InGroup<CHERICapabilityToIntegerCast>;
   InGroup<CHERICapabilityToIntegerCast>, DefaultIgnore;
 def warn_capability_pointer_cast : Warning<
-  "cast from capability type %0 to non-capability type %1 is most likely an error">,
+  "cast from capability type %0 to non-capability type %1 is most likely an "
+   "error; use __cheri_cast to convert between pointers and capabilities">,
   InGroup<CHERICaps>, DefaultError;
 def note_insert_intptr_fixit : Note<
   "insert cast to intptr_t to silence this warning">;
-def note_use_cheri_cast : Note<
-  "use __cheri_cast to convert between pointers and capabilities">;
 def err_cheri_cast_unrelated_type : Error<
   "invalid __cheri_cast from %0 to unrelated type %1">;
 def err_cheri_cast_invalid_target_type: Error<

--- a/include/clang/Basic/TokenKinds.def
+++ b/include/clang/Basic/TokenKinds.def
@@ -563,6 +563,11 @@ KEYWORD(__bridge_transfer            , KEYARC)
 KEYWORD(__bridge_retained            , KEYARC)
 KEYWORD(__bridge_retain              , KEYARC)
 
+
+// CHERI casts to and from capabilities
+KEYWORD(__cheri_cast                 , KEYALL)
+
+
 // Objective-C keywords.
 KEYWORD(__covariant                  , KEYOBJC2)
 KEYWORD(__contravariant              , KEYOBJC2)

--- a/include/clang/Sema/Initialization.h
+++ b/include/clang/Sema/Initialization.h
@@ -875,6 +875,8 @@ public:
     FK_ConversionFailed,
     /// \brief Implicit conversion failed.
     FK_ConversionFromPropertyFailed,
+    /// \brief Implicit conversion failed.
+    FK_ConversionFromCapabilityFailed,
     /// \brief Too many initializers for scalar
     FK_TooManyInitsForScalar,
     /// \brief Scalar initialized from a parenthesized initializer list.

--- a/include/clang/Sema/Initialization.h
+++ b/include/clang/Sema/Initialization.h
@@ -877,6 +877,8 @@ public:
     FK_ConversionFromPropertyFailed,
     /// \brief Implicit conversion failed.
     FK_ConversionFromCapabilityFailed,
+    /// \brief Implicit conversion failed.
+    FK_ConversionToCapabilityFailed,
     /// \brief Too many initializers for scalar
     FK_TooManyInitsForScalar,
     /// \brief Scalar initialized from a parenthesized initializer list.

--- a/include/clang/Sema/Initialization.h
+++ b/include/clang/Sema/Initialization.h
@@ -879,6 +879,8 @@ public:
     FK_ConversionFromCapabilityFailed,
     /// \brief Implicit conversion failed.
     FK_ConversionToCapabilityFailed,
+    /// \brief Reference binding changes __capability qualifier.
+    FK_ReferenceInitChangesCapabilityQualifier,
     /// \brief Too many initializers for scalar
     FK_TooManyInitsForScalar,
     /// \brief Scalar initialized from a parenthesized initializer list.

--- a/include/clang/Sema/Overload.h
+++ b/include/clang/Sema/Overload.h
@@ -193,6 +193,16 @@ namespace clang {
     /// \brief Whether this binds a reference to an object with a different
     /// Objective-C lifetime qualifier.
     unsigned ObjCLifetimeConversionBinding : 1;
+
+    // XXXAR: make this part of the bitfield instead of reusing a field
+    // Will require adding a constructor and adjusting lots of uses
+    // unsigned InvalidCapPointerConversion : 1;
+    bool isInvalidCHERICapabilityConversion() const {
+      return DeprecatedStringLiteralToCharPtr;
+    }
+    void setInvalidCHERIConversion(bool IsInvalid) {
+      DeprecatedStringLiteralToCharPtr = IsInvalid;
+    }
     
     /// FromType - The type that this conversion is converting
     /// from. This is an opaque pointer that can be translated into a

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8068,6 +8068,14 @@ public:
                                   SourceLocation RParenLoc,
                                   Expr *SubExpr);
 
+  ExprResult BuildCheriCast(SourceLocation LParenLoc,
+                            SourceLocation CheriCastKeywordLoc, QualType T,
+                            TypeSourceInfo *TSInfo, Expr *SubExpr);
+
+  ExprResult ActOnCheriCast(Scope *S, SourceLocation LParenLoc,
+                            SourceLocation CheriCastKeywordLoc, ParsedType Type,
+                            SourceLocation RParenLoc, Expr *SubExpr);
+
   void CheckTollFreeBridgeCast(QualType castType, Expr *castExpr);
 
   void CheckObjCBridgeRelatedCast(QualType castType, Expr *castExpr);

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -9212,6 +9212,13 @@ public:
     /// accept as an extension.
     IntToPointer,
 
+    /// CHERICapabilityToPointer - The assignment converts a capability to a
+    /// pointer, which we reject (it needs an explicit __cheri_cast).
+    CHERICapabilityToPointer,
+    /// PointerToCHERICapability - The assignment converts a pointer to a
+    /// capability, which we reject (it needs an explicit __cheri_cast).
+    PointerToCHERICapability,
+
     /// FunctionVoidPointer - The assignment is between a function pointer and
     /// void*, which the standard doesn't allow, but we accept as an extension.
     FunctionVoidPointer,

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -8068,9 +8068,9 @@ public:
                                   SourceLocation RParenLoc,
                                   Expr *SubExpr);
 
-  ExprResult BuildCheriCast(SourceLocation LParenLoc,
-                            SourceLocation CheriCastKeywordLoc, QualType T,
-                            TypeSourceInfo *TSInfo, Expr *SubExpr);
+  ExprResult BuildCheriCast(SourceLocation LParenLoc, SourceLocation KeywordLoc,
+                            QualType DestTy, TypeSourceInfo *TSInfo,
+                            SourceLocation RParenLoc, Expr *SubExpr);
 
   ExprResult ActOnCheriCast(Scope *S, SourceLocation LParenLoc,
                             SourceLocation CheriCastKeywordLoc, ParsedType Type,

--- a/lib/AST/ASTDiagnostic.cpp
+++ b/lib/AST/ASTDiagnostic.cpp
@@ -184,11 +184,15 @@ break; \
     QT = Context.getObjCObjectPointerType(Desugar(Context, Ty->getPointeeType(),
                                                   ShouldAKA));
   } else if (const LValueReferenceType *Ty = QT->getAs<LValueReferenceType>()) {
+    ASTContext::PointerInterpretationKind PIK =
+        Ty->isCHERICapability() ? ASTContext::PIK_Capability : ASTContext::PIK_Integer;
     QT = Context.getLValueReferenceType(Desugar(Context, Ty->getPointeeType(),
-                                                ShouldAKA));
+                                                ShouldAKA), true, PIK);
   } else if (const RValueReferenceType *Ty = QT->getAs<RValueReferenceType>()) {
+    ASTContext::PointerInterpretationKind PIK =
+        Ty->isCHERICapability() ? ASTContext::PIK_Capability : ASTContext::PIK_Integer;
     QT = Context.getRValueReferenceType(Desugar(Context, Ty->getPointeeType(),
-                                                ShouldAKA));
+                                                ShouldAKA), PIK);
   } else if (const auto *Ty = QT->getAs<ObjCObjectType>()) {
     if (Ty->getBaseType().getTypePtr() != Ty && !ShouldAKA) {
       QualType BaseType = Desugar(Context, Ty->getBaseType(), ShouldAKA);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -4015,3 +4015,24 @@ QualType OMPArraySectionExpr::getBaseOriginalType(const Expr *Base) {
   }
   return OriginalTy;
 }
+
+
+QualType Expr::getRealReferenceType() const {
+  const Expr* E = this;
+  // The type of an InitListExpr is void -> if it is a single element one get
+  // the type of that element
+  if (const InitListExpr* ILE = dyn_cast<const InitListExpr>(E)) {
+    if (ILE->getNumInits() == 1)
+      E = ILE->getInit(0);
+  }
+  if (const DeclRefExpr* DRE = dyn_cast<const DeclRefExpr>(E)) {
+    // XXXAR: or should this be getFoundDecl instead of getDecl?
+    if (const ValueDecl* V = dyn_cast_or_null<const ValueDecl>(DRE->getDecl())) {
+      QualType TargetType = V->getType();
+      if (TargetType->isReferenceType()) {
+        return TargetType;
+      }
+    }
+  }
+  return E->getType();
+}

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3031,6 +3031,7 @@ bool AttributedType::isQualifier() const {
   case AttributedType::attr_nullable:
   case AttributedType::attr_null_unspecified:
   case AttributedType::attr_cheri_capability:
+  case AttributedType::attr_memory_address:
     return true;
 
   // These aren't qualifiers; they rewrite the modified type to be a
@@ -3101,6 +3102,7 @@ bool AttributedType::isCallingConv() const {
   case attr_nullable:
   case attr_null_unspecified:
   case attr_objc_kindof:
+  case attr_memory_address:
     return false;
 
   case attr_pcs:

--- a/lib/AST/TypePrinter.cpp
+++ b/lib/AST/TypePrinter.cpp
@@ -1422,6 +1422,9 @@ void TypePrinter::printAttributedAfter(const AttributedType *T,
   case AttributedType::attr_preserve_all:
     OS << "preserve_all";
     break;
+  case AttributedType::attr_memory_address:
+    OS << "memory_address";
+    break;
   }
   OS << "))";
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -951,11 +951,18 @@ static bool parseShowColorsArgs(const ArgList &Args, bool DefaultColor) {
   // but default to off in cc1, needing an explicit OPT_fdiagnostics_color.
   // Support both clang's -f[no-]color-diagnostics and gcc's
   // -f[no-]diagnostics-colors[=never|always|auto].
-  enum {
+  enum ShowColorsEnum {
     Colors_On,
     Colors_Off,
     Colors_Auto
   } ShowColors = DefaultColor ? Colors_Auto : Colors_Off;
+  if (ShowColors == Colors_Auto) {
+    const char* ShowColorsEnv = std::getenv("CLANG_FORCE_COLOR_DIAGNOSTICS");
+    ShowColors = llvm::StringSwitch<ShowColorsEnum>(ShowColorsEnv)
+            .Cases("no", "0", Colors_Off)
+            .Cases("yes", "always", "1", Colors_On)
+            .Default(Colors_Auto);
+  }
   for (Arg *A : Args) {
     const Option &O = A->getOption();
     if (O.matches(options::OPT_fcolor_diagnostics) ||

--- a/lib/Lex/PPMacroExpansion.cpp
+++ b/lib/Lex/PPMacroExpansion.cpp
@@ -1268,6 +1268,7 @@ static bool HasFeature(const Preprocessor &PP, StringRef Feature) {
       .Case("underlying_type", LangOpts.CPlusPlus)
       .Case("capabilities", PP.getTargetInfo().SupportsCapabilities())
       .Case("pointer_interpretation", PP.getTargetInfo().SupportsCapabilities())
+      .Case("__cheri_cast", PP.getTargetInfo().SupportsCapabilities())
       .Default(false);
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2351,6 +2351,25 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool stopIfCastExpr,
     return Actions.ActOnObjCBridgedCast(getCurScope(), OpenLoc, Kind,
                                         BridgeKeywordLoc, Ty.get(),
                                         RParenLoc, SubExpr.get());
+  } else if (Tok.is(tok::kw___cheri_cast)) {
+    // TODO: (__cheri_bounded_cast struct foo[42])?
+    // tok::TokenKind tokenKind = Tok.getKind();
+    SourceLocation CheriCastKeywordLoc = ConsumeToken();
+
+    // Parse a CHERI pointer cast
+    llvm::errs() << "CHERI PTR CAST: is type cast:" << isTypeCast << "\n";
+    TypeResult Ty = ParseTypeName();
+    T.consumeClose();
+    ColonProtection.restore();
+    RParenLoc = T.getCloseLocation();
+    ExprResult SubExpr = ParseCastExpression(/*isUnaryExpression=*/false);
+
+    if (Ty.isInvalid() || SubExpr.isInvalid())
+      return ExprError();
+
+    return Actions.ActOnCheriCast(getCurScope(), OpenLoc,
+                                         CheriCastKeywordLoc, Ty.get(),
+                                         RParenLoc, SubExpr.get());
   } else if (ExprType >= CompoundLiteral &&
              isTypeIdInParens(isAmbiguousTypeId)) {
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2357,7 +2357,6 @@ Parser::ParseParenExpression(ParenParseOption &ExprType, bool stopIfCastExpr,
     SourceLocation CheriCastKeywordLoc = ConsumeToken();
 
     // Parse a CHERI pointer cast
-    llvm::errs() << "CHERI PTR CAST: is type cast:" << isTypeCast << "\n";
     TypeResult Ty = ParseTypeName();
     T.consumeClose();
     ColonProtection.restore();

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1769,6 +1769,7 @@ static void DiagnoseCHERICast(Sema &Self, Expr *SrcExpr, QualType DestType,
         << static_cast<unsigned>(SrcAlign.getQuantity())
         << static_cast<unsigned>(DestAlign.getQuantity())
         << Range << SrcExpr->getSourceRange();
+      Self.Diag(Range.getEnd(), diag::note_cheri_cast_align_fixit);
     }
   }
 }

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1784,6 +1784,9 @@ static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
   if (DestType->isVoidType()) {
     return; // casting to void to silence unused variable warnings is fine
   }
+  if (SrcType->isNullPtrType()) {
+    return;
+  }
 
   const QualType CanonicalSrcType = SrcType.getCanonicalType();
   if (const BuiltinType *BT = dyn_cast<BuiltinType>(CanonicalSrcType)) {

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -705,7 +705,8 @@ void CastOperation::CheckDynamicCast() {
   }
 
   // Check that the dynamic cast doesn't change the capability qualifier
-  if (IsBadCheriReferenceCast(DestReference, SrcExpr.get(), Self.getASTContext())) {
+  if (DestReference && IsBadCheriReferenceCast(DestReference, SrcExpr.get(),
+                                               Self.getASTContext())) {
     Self.Diag(OpRange.getBegin(), diag::err_bad_cxx_reference_cast_capability_qualifier)
             << CT_Dynamic << 0 << DestType;
     SrcExpr = ExprError();

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1781,6 +1781,9 @@ static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
   if (DestType->isCHERICapabilityType(Self.Context)) {
     return; // cast from capabilty to capability is fine
   }
+  if (DestType->isVoidType()) {
+    return; // casting to void to silence unused variable warnings is fine
+  }
 
   const QualType CanonicalSrcType = SrcType.getCanonicalType();
   if (const BuiltinType *BT = dyn_cast<BuiltinType>(CanonicalSrcType)) {

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1818,8 +1818,11 @@ static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
   if (!IsMemAddressType) {
     Self.Diag(OpRange.getBegin(), diag::warn_capability_integer_cast)
       << SrcType << DestType << OpRange;
-    Self.Diag(OpRange.getEnd(), diag::note_insert_vaddr_or_intptr_fixit)
-      << FixItHint::CreateInsertion(OpRange.getEnd(), "(vaddr_t)");
+  }
+  if (DestType->isPointerType()) {
+    Self.Diag(OpRange.getEnd(), diag::note_use_cheri_cast)
+      << FixItHint::CreateReplacement(OpRange, "__cheri_cast " +
+                                               DestType.getAsString());
   }
 }
 

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2794,7 +2794,9 @@ ExprResult Sema::BuildCXXFunctionalCastExpr(TypeSourceInfo *CastTypeInfo,
     SubExpr = BindExpr->getSubExpr();
   if (auto *ConstructExpr = dyn_cast<CXXConstructExpr>(SubExpr))
     ConstructExpr->setParenOrBraceRange(SourceRange(LPLoc, RPLoc));
-  DiagnoseCapabilityToIntCast(*this, Op.DestRange, CastExpr->getType(), Type);
+  else /* XXXAR: only diagnose int<->cap casts for actual casts */
+    DiagnoseCapabilityToIntCast(*this, Op.DestRange, CastExpr->getType(), Type);
+
   return Op.complete(CXXFunctionalCastExpr::Create(Context, Op.ResultType,
                          Op.ValueKind, CastTypeInfo, Op.Kind,
                          Op.SrcExpr.get(), &Op.BasePath, LPLoc, RPLoc));

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1832,14 +1832,15 @@ static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
     }
     CurTy = Desugared;
   }
-  if (!IsMemAddressType) {
-    Self.Diag(OpRange.getBegin(), diag::warn_capability_integer_cast)
-      << SrcType << DestType << OpRange;
-  }
   if (DestType->isPointerType()) {
+    Self.Diag(OpRange.getBegin(), diag::warn_capability_pointer_cast)
+            << SrcType << DestType << OpRange;
     Self.Diag(OpRange.getEnd(), diag::note_use_cheri_cast)
       << FixItHint::CreateReplacement(OpRange, "__cheri_cast " +
                                                DestType.getAsString());
+  } else if (!IsMemAddressType) {
+      Self.Diag(OpRange.getBegin(), diag::warn_capability_integer_cast)
+              << SrcType << DestType << OpRange;
   }
 }
 

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -209,6 +209,9 @@ static TryCastResult TryReinterpretCast(Sema &Self, ExprResult &SrcExpr,
                                         unsigned &msg,
                                         CastKind &Kind);
 
+static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
+                                        QualType SrcType, QualType DestType);
+
 
 /// ActOnCXXNamedCast - Parse {dynamic,static,reinterpret,const}_cast's.
 ExprResult
@@ -259,6 +262,7 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
         return ExprError();
       DiscardMisalignedMemberAddress(DestType.getTypePtr(), E);
     }
+    DiagnoseCapabilityToIntCast(*this, AngleBrackets, E->getType(), DestType);
     return Op.complete(CXXConstCastExpr::Create(Context, Op.ResultType,
                                   Op.ValueKind, Op.SrcExpr.get(), DestTInfo,
                                                 OpLoc, Parens.getEnd(),
@@ -270,6 +274,7 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
       if (Op.SrcExpr.isInvalid())
         return ExprError();
     }
+    DiagnoseCapabilityToIntCast(*this, AngleBrackets, E->getType(), DestType);
     return Op.complete(CXXDynamicCastExpr::Create(Context, Op.ResultType,
                                     Op.ValueKind, Op.Kind, Op.SrcExpr.get(),
                                                   &Op.BasePath, DestTInfo,
@@ -283,6 +288,7 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
         return ExprError();
       DiscardMisalignedMemberAddress(DestType.getTypePtr(), E);
     }
+    DiagnoseCapabilityToIntCast(*this, AngleBrackets, E->getType(), DestType);
     return Op.complete(CXXReinterpretCastExpr::Create(Context, Op.ResultType,
                                     Op.ValueKind, Op.Kind, Op.SrcExpr.get(),
                                                       nullptr, DestTInfo, OpLoc,
@@ -294,6 +300,7 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
       Op.CheckStaticCast();
       if (Op.SrcExpr.isInvalid())
         return ExprError();
+      DiagnoseCapabilityToIntCast(*this, AngleBrackets, E->getType(), DestType);
       DiscardMisalignedMemberAddress(DestType.getTypePtr(), E);
     }
     
@@ -1768,8 +1775,10 @@ static void DiagnoseCHERICast(Sema &Self, Expr *SrcExpr, QualType DestType,
 
 static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
                                         QualType SrcType, QualType DestType) {
-  assert(SrcType->isMemoryCapabilityType(Self.Context));
-  if (DestType->isMemoryCapabilityType(Self.Context)) {
+  if (!SrcType->isCHERICapabilityType(Self.Context)) {
+    return; // Not casting from a capability
+  }
+  if (DestType->isCHERICapabilityType(Self.Context)) {
     return; // cast from capabilty to capability is fine
   }
 
@@ -1940,8 +1949,7 @@ static void checkIntToPointerCast(bool CStyle, SourceLocation Loc,
   unsigned AS = DestType->getPointeeType().getAddressSpace();
   ASTContext &Ctx = Self.getASTContext();
 
-  if (Ctx.getTargetInfo().areAllPointersCapabilities() &&
-      DestType->isCHERICapabilityType(Ctx) &&
+  if (DestType->isCHERICapabilityType(Ctx) &&
       !SrcType->isCHERICapabilityType(Ctx) &&
       !SrcExpr->isIntegerConstantExpr(Ctx)) {
     Self.Diag(Loc, diag::warn_capability_no_provenance) << DestType;
@@ -2192,11 +2200,6 @@ static TryCastResult TryReinterpretCast(Sema &Self, ExprResult &SrcExpr,
     // C++ 5.2.10p4: A pointer can be explicitly converted to any integral
     //   type large enough to hold it; except in Microsoft mode, where the
     //   integral type size doesn't matter (except we don't allow bool).
-
-    if (SrcType->isMemoryCapabilityType(Self.Context)) {
-      DiagnoseCapabilityToIntCast(Self, OpRange, /*SrcExpr.get()->getLocStart(),*/
-                                  SrcType, DestType);
-    }
     bool MicrosoftException = Self.getLangOpts().MicrosoftExt &&
                               !DestType->isBooleanType();
     bool IsCap = SrcType->isCHERICapabilityType(Self.Context);
@@ -2703,10 +2706,6 @@ void CastOperation::CheckCStyleCast() {
       return;
     }
   }
-  if (SrcType->isMemoryCapabilityType(Self.Context)) {
-    DiagnoseCapabilityToIntCast(Self, DestRange, /* SrcExpr.get()->getLocStart(), */
-                                SrcType, DestType);
-  }
   DiagnoseCHERICallback(Self, SrcExpr.get()->getLocStart(), SrcType, DestType);
   DiagnoseCastOfObjCSEL(Self, SrcExpr, DestType);
   DiagnoseCallingConvCast(Self, SrcExpr, DestType, OpRange);
@@ -2762,6 +2761,9 @@ ExprResult Sema::BuildCStyleCastExpr(SourceLocation LPLoc,
   if (Op.SrcExpr.isInvalid())
     return ExprError();
 
+  DiagnoseCapabilityToIntCast(*this, Op.DestRange, CastExpr->getType(),
+                              CastTypeInfo->getType());
+
   return Op.complete(CStyleCastExpr::Create(Context, Op.ResultType,
                               Op.ValueKind, Op.Kind, Op.SrcExpr.get(),
                               &Op.BasePath, CastTypeInfo, LPLoc, RPLoc));
@@ -2786,7 +2788,7 @@ ExprResult Sema::BuildCXXFunctionalCastExpr(TypeSourceInfo *CastTypeInfo,
     SubExpr = BindExpr->getSubExpr();
   if (auto *ConstructExpr = dyn_cast<CXXConstructExpr>(SubExpr))
     ConstructExpr->setParenOrBraceRange(SourceRange(LPLoc, RPLoc));
-
+  DiagnoseCapabilityToIntCast(*this, Op.DestRange, CastExpr->getType(), Type);
   return Op.complete(CXXFunctionalCastExpr::Create(Context, Op.ResultType,
                          Op.ValueKind, CastTypeInfo, Op.Kind,
                          Op.SrcExpr.get(), &Op.BasePath, LPLoc, RPLoc));
@@ -2796,14 +2798,14 @@ ExprResult Sema::BuildCheriCast(SourceLocation LParenLoc,
                                 SourceLocation KeywordLoc, QualType DestTy,
                                 TypeSourceInfo *TSInfo,
                                 SourceLocation RParenLoc, Expr *SubExpr) {
-  bool DestIsCap = DestTy->isMemoryCapabilityType(Context);
+  bool DestIsCap = DestTy->isCHERICapabilityType(Context);
   if (!DestTy->isPointerType() && !DestIsCap) {
     Diag(TSInfo->getTypeLoc().getLocStart(),
          diag::err_cheri_cast_invalid_target_type) << DestTy;
     return ExprError();
   }
   QualType SrcTy = SubExpr->getType();
-  bool SrcIsCap = SrcTy->isMemoryCapabilityType(Context);
+  bool SrcIsCap = SrcTy->isCHERICapabilityType(Context);
   if (!SrcTy->isPointerType() && !SrcIsCap) {
     Diag(SubExpr->getLocStart(), diag::err_cheri_cast_invalid_source_type)
       << SrcTy;

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1836,8 +1836,7 @@ static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
   }
   if (DestType->isPointerType() || DestType->isReferenceType()) {
     Self.Diag(OpRange.getBegin(), diag::warn_capability_pointer_cast)
-            << SrcType << DestType << OpRange;
-    Self.Diag(OpRange.getEnd(), diag::note_use_cheri_cast)
+      << SrcType << DestType << OpRange
       << FixItHint::CreateReplacement(OpRange, "__cheri_cast " +
                                                DestType.getAsString());
   } else if (!IsMemAddressType) {

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -48,7 +48,7 @@ enum CastType {
 };
 
 static CastKind DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
-                                        const Expr* E, QualType DestType);
+                                            const Expr *E, QualType DestType);
 
 namespace {
   struct CastOperation {
@@ -589,8 +589,8 @@ CastsAwayConstness(Sema &Self, QualType SrcType, QualType DestType,
                                     ObjCLifetimeConversion);
 }
 
-static bool IsBadCheriReferenceCast(const ReferenceType* Dest, Expr* SrcExpr,
-                                    const ASTContext& Ctx) {
+static bool IsBadCheriReferenceCast(const ReferenceType *Dest, Expr *SrcExpr,
+                                    const ASTContext &Ctx) {
   bool SrcIsCapRef = Ctx.getTargetInfo().areAllPointersCapabilities();
   if (auto SrcRef = SrcExpr->getRealReferenceType()->getAs<ReferenceType>())
     SrcIsCapRef = SrcRef->isCHERICapability();
@@ -623,7 +623,7 @@ void CastOperation::CheckDynamicCast() {
     DestPointee = DestReference->getPointeeType();
   } else {
     Self.Diag(OpRange.getBegin(), diag::err_bad_dynamic_cast_not_ref_or_ptr)
-      << this->DestType << DestRange;
+        << this->DestType << DestRange;
     SrcExpr = ExprError();
     return;
   }
@@ -1638,7 +1638,8 @@ static TryCastResult TryConstCast(Sema &Self, ExprResult &SrcExpr,
       return TC_NotApplicable;
     }
 
-    if (IsBadCheriReferenceCast(DestTypeTmp, SrcExpr.get(), Self.getASTContext())) {
+    if (IsBadCheriReferenceCast(DestTypeTmp, SrcExpr.get(),
+                                Self.getASTContext())) {
       msg = diag::err_bad_cxx_reference_cast_capability_qualifier;
       return TC_NotApplicable;
     }
@@ -1811,7 +1812,7 @@ static void DiagnoseCHERICast(Sema &Self, Expr *SrcExpr, QualType DestType,
 }
 
 static CastKind DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
-                                            const Expr* SrcExpr,
+                                            const Expr *SrcExpr,
                                             QualType DestType) {
   QualType SrcType = SrcExpr->getRealReferenceType();
   if (SrcType->isDependentType() || DestType->isDependentType())
@@ -1856,7 +1857,7 @@ static CastKind DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
         // llvm::errs() << "Found attr_memory_address: " << CurTy.getAsString() << "\n";
         // llvm::errs() << DestType.getAsString() << " is a memoryAddressType!\n";
         IsMemAddressType = true;
-	    break;
+        break;
       }
     }
     if (!CurTy->isIntegralType(Self.Context)) {
@@ -1873,14 +1874,14 @@ static CastKind DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
   }
   if (DestType->isPointerType() || DestType->isReferenceType()) {
     Self.Diag(OpRange.getBegin(), diag::warn_capability_pointer_cast)
-      << SrcType << DestType << OpRange
-      << FixItHint::CreateReplacement(OpRange, "__cheri_cast " +
-                                               DestType.getAsString());
+        << SrcType << DestType << OpRange
+        << FixItHint::CreateReplacement(OpRange, "__cheri_cast " +
+                                                     DestType.getAsString());
     return CK_CHERICapabilityToPointer;
 
   } else if (!IsMemAddressType) {
-      Self.Diag(OpRange.getBegin(), diag::warn_capability_integer_cast)
-              << SrcType << DestType << OpRange;
+    Self.Diag(OpRange.getBegin(), diag::warn_capability_integer_cast)
+        << SrcType << DestType << OpRange;
   }
   return CK_NoOp;
 }
@@ -2865,18 +2866,18 @@ ExprResult Sema::BuildCheriCast(SourceLocation LParenLoc,
     return ExprError();
   }
   bool TypesCompatible = false;
-  if (getLangOpts().CPlusPlus) {
-    // C++ checks if the types are excatly the same -> this will fail because
-    // capability and non-capability Type* are different instances
-    //
-    // Types compatible source:
-    //   if (getLangOpts().CPlusPlus)
-    //     return hasSameType(LHS, RHS);
-    //  return !mergeTypes(LHS, RHS, false, CompareUnqualified).isNull();
+  // C++ checks if the types are excatly the same -> this will fail because
+  // capability and non-capability Type* are different instances
+  //
+  // Types compatible source:
+  //   if (getLangOpts().CPlusPlus)
+  //     return hasSameType(LHS, RHS);
+  //  return !mergeTypes(LHS, RHS, false, CompareUnqualified).isNull();
+  if (getLangOpts().CPlusPlus)
     TypesCompatible = !Context.mergeTypes(SrcTy, DestTy, false, false).isNull();
-  } else {
+  else
     TypesCompatible = Context.typesAreCompatible(SrcTy, DestTy, false);
-  }
+
   if (!TypesCompatible) {
     Diag(SubExpr->getLocStart(), diag::err_cheri_cast_unrelated_type)
       << SrcTy << DestTy;

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -2837,11 +2837,11 @@ ExprResult Sema::BuildCheriCast(SourceLocation LParenLoc,
   }
   CastKind Kind = CK_NoOp;
   if (SrcIsCap && !DestIsCap) {
-    Kind = CK_MemoryCapabilityToPointer;
+    Kind = CK_CHERICapabilityToPointer;
     assert(!Context.getTargetInfo().areAllPointersCapabilities() &&
            "__cheri_cast to pointer should not be possible in purecap mode");
   } else if (DestIsCap && !SrcIsCap) {
-    Kind = CK_PointerToMemoryCapability;
+    Kind = CK_PointerToCHERICapability;
   } else {
     // Warn about no-op cheri casts in hybrid mode. In purecap mode all casts
     // should be noops but we don't warn to allow compiling the same code

--- a/lib/Sema/SemaCast.cpp
+++ b/lib/Sema/SemaCast.cpp
@@ -1775,6 +1775,8 @@ static void DiagnoseCHERICast(Sema &Self, Expr *SrcExpr, QualType DestType,
 
 static void DiagnoseCapabilityToIntCast(Sema &Self, SourceRange OpRange,
                                         QualType SrcType, QualType DestType) {
+  if (SrcType->isDependentType() || DestType->isDependentType())
+    return; // can't diagnose this yet
   if (!SrcType->isCHERICapabilityType(Self.Context)) {
     return; // Not casting from a capability
   }

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6612,10 +6612,6 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_XRayLogArgs:
     handleXRayLogArgsAttr(S, D, Attr);
     break;
-//   case AttributeList::AT_MemoryAddress:
-//     D->dump(llvm::errs());
-//     assert(false && "AT_MEMORY_ADDRESS in declattr");
-//     break;
   }
 }
 

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -6612,6 +6612,10 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case AttributeList::AT_XRayLogArgs:
     handleXRayLogArgsAttr(S, D, Attr);
     break;
+//   case AttributeList::AT_MemoryAddress:
+//     D->dump(llvm::errs());
+//     assert(false && "AT_MEMORY_ADDRESS in declattr");
+//     break;
   }
 }
 

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13246,8 +13246,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     isInvalid = true;
     Hint = FixItHint::CreateInsertion(SrcExpr->getLocStart(), "(__cheri_cast " +
                                       DstType.getAsString() + ")");
-    // make sure that the source type comes first in the diagnostic:
-    Action = AA_Converting;  // XXXAR: not sure this is 100% correct
+    Diag(Loc, DiagKind) << SrcType << DstType << false << Hint;
+    return true;
     break;
   case Incompatible:
     if (maybeDiagnoseAssignmentToFunction(*this, DstType, SrcExpr)) {

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -7698,9 +7698,9 @@ Sema::CheckAssignmentConstraints(QualType LHSType, ExprResult &RHS,
     if (const PointerType *RHSPointer = dyn_cast<PointerType>(RHSType)) {
       unsigned AddrSpaceL = LHSPointer->getPointeeType().getAddressSpace();
       unsigned AddrSpaceR = RHSPointer->getPointeeType().getAddressSpace();
-      if (AddrSpaceL != AddrSpaceR) {
+      if (AddrSpaceL != AddrSpaceR)
         Kind = CK_AddressSpaceConversion;
-      } else if (LHSPointer->isFunctionPointerType() && RHSPointer->isFunctionPointerType()) {
+      else if (LHSPointer->isFunctionPointerType() && RHSPointer->isFunctionPointerType()) {
         // only allow implicit casts to and from function pointer capabilities
         if (!LHSPointer->isCHERICapability() && RHSPointer->isCHERICapability())
           Kind = CK_CHERICapabilityToPointer;

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -13236,6 +13236,9 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     break;
   case CHERICapabilityToPointer:
   case PointerToCHERICapability:
+    if (isa<StringLiteral>(SrcExpr->IgnoreParens()->IgnoreImpCasts())) {
+      return false; // conversion from string to capability is fine
+    }
     DiagKind = (ConvTy == CHERICapabilityToPointer)
         ? diag::err_typecheck_convert_cap_to_ptr
         : diag::err_typecheck_convert_ptr_to_cap;

--- a/lib/Sema/SemaExprCXX.cpp
+++ b/lib/Sema/SemaExprCXX.cpp
@@ -3966,7 +3966,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
       if (SCS.isInvalidCHERICapabilityConversion()) {
         unsigned DiagID = FromIsCap ? diag::err_typecheck_convert_cap_to_ptr :
                                       diag::err_typecheck_convert_ptr_to_cap;
-        Diag(From->getLocStart(), DiagID) << FromType << ToType
+        Diag(From->getLocStart(), DiagID) << FromType << ToType << false
             << FixItHint::CreateInsertion(From->getLocStart(), "(__cheri_cast " +
                                           ToType.getAsString() + ")");
         return ExprError();

--- a/lib/Sema/SemaExprCXX.cpp
+++ b/lib/Sema/SemaExprCXX.cpp
@@ -3961,7 +3961,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                                   From->getValueKind() : VK_RValue;
     const bool FromIsCap = FromType->isCHERICapabilityType(Context);
     const bool ToIsCap = ToType->isCHERICapabilityType(Context);
-    if (FromIsCap != ToIsCap) {
+    if (FromIsCap != ToIsCap && SCS.isInvalidCHERICapabilityConversion()) {
       unsigned DiagID = FromIsCap ? diag::err_typecheck_convert_cap_to_ptr :
                                     diag::err_typecheck_convert_ptr_to_cap;
       Diag(From->getLocStart(), DiagID) << FromType << ToType

--- a/lib/Sema/SemaExprCXX.cpp
+++ b/lib/Sema/SemaExprCXX.cpp
@@ -3959,6 +3959,16 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
     // target type isn't a reference.
     ExprValueKind VK = ToType->isReferenceType() ?
                                   From->getValueKind() : VK_RValue;
+    const bool FromIsCap = FromType->isCHERICapabilityType(Context);
+    const bool ToIsCap = ToType->isCHERICapabilityType(Context);
+    if (FromIsCap != ToIsCap) {
+      unsigned DiagID = FromIsCap ? diag::err_typecheck_convert_cap_to_ptr :
+                                    diag::err_typecheck_convert_ptr_to_cap;
+      Diag(From->getLocStart(), DiagID) << FromType << ToType
+          << FixItHint::CreateInsertion(From->getLocStart(), "(__cheri_cast " +
+                                        ToType.getAsString() + ")");
+      return ExprError();
+    }
     From = ImpCastExprToType(From, ToType.getNonLValueExprType(Context),
                              CK_NoOp, VK, /*BasePath=*/nullptr, CCK).get();
 

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -4044,7 +4044,7 @@ static void TryListInitialization(Sema &S,
       // source value is already of the destination type), and the first
       // case is handled by the general case for single-element lists below.
       ImplicitConversionSequence ICS;
-      ICS.setStandard();
+      ICS.setStandard(ImplicitConversionSequence::MemsetToZero);
       ICS.Standard.setAsIdentityConversion();
       if (!E->isRValue())
         ICS.Standard.First = ICK_Lvalue_To_Rvalue;
@@ -4261,8 +4261,7 @@ static OverloadingResult TryRefInitWithConversionFunction(
            "should not have conversion after constructor");
 
     ImplicitConversionSequence ICS;
-    ICS.setStandard();
-    ICS.Standard = Best->FinalConversion;
+    ICS.setStandard(Best->FinalConversion);
     Sequence.AddConversionSequenceStep(ICS, ICS.Standard.getToType(2));
 
     // Every implicit conversion results in a prvalue, except for a glvalue
@@ -4883,8 +4882,7 @@ static void TryUserDefinedConversion(Sema &S,
   if (Best->FinalConversion.First || Best->FinalConversion.Second ||
       Best->FinalConversion.Third) {
     ImplicitConversionSequence ICS;
-    ICS.setStandard();
-    ICS.Standard = Best->FinalConversion;
+    ICS.setStandard(Best->FinalConversion);
     Sequence.AddConversionSequenceStep(ICS, DestType, TopLevelOfInitList);
   }
 }
@@ -5040,7 +5038,7 @@ static bool tryObjCWritebackConversion(Sema &S,
   // Do we need an lvalue conversion?
   if (ArrayDecay || Initializer->isGLValue()) {
     ImplicitConversionSequence ICS;
-    ICS.setStandard();
+    ICS.setStandard(ImplicitConversionSequence::MemsetToZero);
     ICS.Standard.setAsIdentityConversion();
 
     QualType ResultType;
@@ -5472,7 +5470,7 @@ void InitializationSequence::InitializeFrom(Sema &S,
     if (ICS.Standard.First == ICK_Array_To_Pointer ||
         ICS.Standard.First == ICK_Lvalue_To_Rvalue) {
       ImplicitConversionSequence LvalueICS;
-      LvalueICS.setStandard();
+      LvalueICS.setStandard(ImplicitConversionSequence::MemsetToZero);
       LvalueICS.Standard.setAsIdentityConversion();
       LvalueICS.Standard.setAllToTypes(ICS.Standard.getToType(0));
       LvalueICS.Standard.First = ICS.Standard.First;

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -2114,7 +2114,6 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
                                             unsigned &StructuredIndex,
                                             bool FinishSubobjectInit,
                                             bool TopLevelObject) {
-  // FIXME: add a test case for C99 initiliazers
   if (DesigIdx == DIE->size()) {
     // Check the actual initialization for the designated object type.
     bool prevHadError = hadError;

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -7685,7 +7685,16 @@ bool InitializationSequence::Diagnose(Sema &S,
     break;
 
   case FK_ConversionFromCapabilityFailed:
-  case FK_ConversionToCapabilityFailed:
+  case FK_ConversionToCapabilityFailed: {
+    QualType FromType = Args[0]->getType();
+    unsigned DiagID = Failure == FK_ConversionFromCapabilityFailed
+        ? diag::err_typecheck_convert_cap_to_ptr
+        : diag::err_typecheck_convert_ptr_to_cap;
+    S.Diag(Kind.getLocation(), DiagID) << FromType << DestType
+      << FixItHint::CreateInsertion(Kind.getLocation(), "(__cheri_cast " +
+                                    DestType.getAsString() + ")");
+    break;
+  }
   case FK_ConversionFailed: {
     QualType FromType = Args[0]->getType();
     PartialDiagnostic PDiag = S.PDiag(diag::err_init_conversion_failed)

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -1316,8 +1316,8 @@ bool InitListChecker::isCapNarrowing(Expr* expr, QualType DeclType,
                                      llvm::Optional<QualType> exprType) {
   // extra parameter needed because expr->getType() returns `int` for `int & __capability`
   QualType ExprType = exprType ? *exprType : expr->getType();
-  if (ExprType->isMemoryCapabilityType(SemaRef.Context) &&
-     !DeclType->isMemoryCapabilityType(SemaRef.Context)) {
+  if (ExprType->isCHERICapabilityType(SemaRef.Context) &&
+     !DeclType->isCHERICapabilityType(SemaRef.Context)) {
     // TODO: allow for nullptr, etc.
     if (!VerifyOnly) {
       SemaRef.Diag(expr->getLocStart(), diag::ext_init_list_type_narrowing)
@@ -5499,12 +5499,12 @@ void InitializationSequence::InitializeFrom(Sema &S,
       SetFailed(InitializationSequence::FK_ConversionFailed);
   } else {
     if (ICS.isStandard() && ICS.Standard.Third == ICK_Qualification) {
-      if (SourceType->isMemoryCapabilityType(Context) &&
-        !DestType->isMemoryCapabilityType(Context)) {
+      if (SourceType->isCHERICapabilityType(Context) &&
+        !DestType->isCHERICapabilityType(Context)) {
           SetFailed(InitializationSequence::FK_ConversionFromCapabilityFailed);
           return;
-      } else if (DestType->isMemoryCapabilityType(Context) &&
-          !SourceType->isMemoryCapabilityType(Context)) {
+      } else if (DestType->isCHERICapabilityType(Context) &&
+          !SourceType->isCHERICapabilityType(Context)) {
         // don't warn on null -> capability conversion
         // XXXAR: is this the correct NPC_ value?
         if (!(Initializer && Initializer->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull))) {

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -5496,17 +5496,19 @@ void InitializationSequence::InitializeFrom(Sema &S,
     else
       SetFailed(InitializationSequence::FK_ConversionFailed);
   } else {
-    if (SourceType->isMemoryCapabilityType(Context) &&
-      !DestType->isMemoryCapabilityType(Context)) {
-        SetFailed(InitializationSequence::FK_ConversionFromCapabilityFailed);
-        return;
-    } else if (DestType->isMemoryCapabilityType(Context) &&
-        !SourceType->isMemoryCapabilityType(Context)) {
-      // don't warn on null -> capability conversion
-      // XXXAR: is this the correct NPC_ value?
-      if (!(Initializer && Initializer->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull))) {
-        SetFailed(InitializationSequence::FK_ConversionToCapabilityFailed);
-        return;
+    if (ICS.isStandard() && ICS.Standard.Third == ICK_Qualification) {
+      if (SourceType->isMemoryCapabilityType(Context) &&
+        !DestType->isMemoryCapabilityType(Context)) {
+          SetFailed(InitializationSequence::FK_ConversionFromCapabilityFailed);
+          return;
+      } else if (DestType->isMemoryCapabilityType(Context) &&
+          !SourceType->isMemoryCapabilityType(Context)) {
+        // don't warn on null -> capability conversion
+        // XXXAR: is this the correct NPC_ value?
+        if (!(Initializer && Initializer->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull))) {
+          SetFailed(InitializationSequence::FK_ConversionToCapabilityFailed);
+          return;
+        }
       }
     }
     AddConversionSequenceStep(ICS, DestType, TopLevelOfInitList);

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -1452,15 +1452,17 @@ void InitListChecker::CheckReferenceType(const InitializedEntity &Entity,
     hadError = true;
 
   expr = Result.getAs<Expr>();
-  llvm::Optional<QualType> exprType = None;
-  if (DeclRefExpr* DRE = dyn_cast<DeclRefExpr>(expr)) {
-    if (ValueDecl* V = dyn_cast_or_null<ValueDecl>(DRE->getFoundDecl())) {
-      exprType = V->getType();
+  if (expr) {
+    llvm::Optional<QualType> exprType = None;
+    if (DeclRefExpr* DRE = dyn_cast<DeclRefExpr>(expr)) {
+      if (ValueDecl* V = dyn_cast_or_null<ValueDecl>(DRE->getFoundDecl())) {
+        exprType = V->getType();
+      }
     }
-  }
-  if (isCapNarrowing(expr, DeclType, &Index, &StructuredIndex, exprType)) {
-    hadError = true;
-    return;
+    if (isCapNarrowing(expr, DeclType, &Index, &StructuredIndex, exprType)) {
+      hadError = true;
+      return;
+    }
   }
   IList->setInit(Index, expr);
 

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -5507,7 +5507,9 @@ void InitializationSequence::InitializeFrom(Sema &S,
           !SourceType->isCHERICapabilityType(Context)) {
         // don't warn on null -> capability conversion
         // XXXAR: is this the correct NPC_ value?
-        if (!(Initializer && Initializer->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull))) {
+        bool SrcIsNull = (Initializer &&
+            Initializer->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull));
+        if (!SrcIsNull && ICS.Standard.isInvalidCHERICapabilityConversion()) {
           SetFailed(InitializationSequence::FK_ConversionToCapabilityFailed);
           return;
         }

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -1175,10 +1175,6 @@ void InitListChecker::CheckSubElementType(const InitializedEntity &Entity,
     // Brace elision is never performed if the element is not an
     // assignment-expression.
     if (Seq || isa<InitListExpr>(expr)) {
-      if (isCapNarrowing(expr, ElemType, &Index, &StructuredIndex)) {
-        hadError = true;
-        return;
-      }
       if (!VerifyOnly) {
         ExprResult Result =
           Seq.Perform(SemaRef, Entity, Kind, expr);

--- a/lib/Sema/SemaInit.cpp
+++ b/lib/Sema/SemaInit.cpp
@@ -4332,10 +4332,14 @@ static void CheckReferenceInitCHERI(Sema& S, const InitializedEntity &Entity,
   const bool PureCapABI = S.getASTContext().getTargetInfo().areAllPointersCapabilities();
   // If we are in the purecap ABI we can't create non-capabality references so no need to check
   if (!PureCapABI) {
-    bool DestIsCap = Entity.getType()->isCHERICapabilityType(S.getASTContext());
+    bool DestIsCapRef = PureCapABI;
+    if (auto DestRef = Entity.getType()->getAs<ReferenceType>())
+      DestIsCapRef = DestRef->isCHERICapability();
     QualType RealSrcType = Initializer->getRealReferenceType();
-    bool SrcExprIsCap = RealSrcType->isCHERICapabilityType(S.getASTContext());
-    if (DestIsCap != SrcExprIsCap) {
+    bool SrcIsCapRef = false;
+    if (auto SrcRef = RealSrcType->getAs<ReferenceType>())
+      SrcIsCapRef = SrcRef->isCHERICapability();
+    if (SrcIsCapRef != DestIsCapRef) {
       Sequence.SetFailed(InitializationSequence::FK_ReferenceInitChangesCapabilityQualifier);
       return;
     }

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -1827,6 +1827,16 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
     SCS.Third = ICK_Qualification;
     SCS.QualificationIncludesObjCLifetime = ObjCLifetimeConversion;
     // This may change the __capability qualifier so we need to diagnose it later
+    if (ToType->isCHERICapabilityType(S.getASTContext()) !=
+        FromType->isCHERICapabilityType(S.getASTContext())) {
+      // only allow implicit conversions from string literals
+      // XXXAR: should we allow any array type?
+      if (!isa<StringLiteral>(From->IgnoreParens())) {
+        // XXXAR: we should really add a new field to SCS instead of using the
+        // deprecated string literal one
+        SCS.setInvalidCHERIConversion(true);
+      }
+    }
     FromType = ToType;
   } else {
     // No conversion required

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -1568,7 +1568,6 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
   SCS.IncompatibleObjC = false;
   SCS.setFromType(FromType);
   SCS.CopyConstructor = nullptr;
-  // assert(!SCS.IncompatibleCHERIConversion);
 
   // There are no standard conversions for class types in C++, so
   // abort early. When overloading in C, however, we do permit them.

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -1826,12 +1826,8 @@ static bool IsStandardConversion(Sema &S, Expr* From, QualType ToType,
                                          ObjCLifetimeConversion)) {
     SCS.Third = ICK_Qualification;
     SCS.QualificationIncludesObjCLifetime = ObjCLifetimeConversion;
-    // don't allow conversions between __capability and integer pointers
-    if (FromType->isMemoryCapabilityType(S.getASTContext()) ==
-        ToType->isMemoryCapabilityType(S.getASTContext())) {
-      // SCS.Third = ICK_Incompatible_Pointer_Conversion;
-      FromType = ToType;
-    }
+    // This may change the __capability qualifier so we need to diagnose it later
+    FromType = ToType;
   } else {
     // No conversion required
     SCS.Third = ICK_Identity;

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -4749,10 +4749,7 @@ TryListConversion(Sema &S, InitListExpr *From, QualType ToType,
         InitializedEntity::InitializeParameter(S.Context, ToType,
                                                /*Consumed=*/false);
       if (S.CanPerformCopyInitialization(Entity, From)) {
-        Result.setStandard();
-        Result.Standard.setAsIdentityConversion();
-        Result.Standard.setFromType(ToType);
-        Result.Standard.setAllToTypes(ToType);
+        Result.setAsIdentityConversion(ToType);
         return Result;
       }
     }
@@ -4802,10 +4799,7 @@ TryListConversion(Sema &S, InitListExpr *From, QualType ToType,
     // For an empty list, we won't have computed any conversion sequence.
     // Introduce the identity conversion sequence.
     if (From->getNumInits() == 0) {
-      Result.setStandard();
-      Result.Standard.setAsIdentityConversion();
-      Result.Standard.setFromType(ToType);
-      Result.Standard.setAllToTypes(ToType);
+      Result.setAsIdentityConversion(ToType);
     }
 
     Result.setStdInitializerListElement(toStdInitializerList);
@@ -4943,10 +4937,7 @@ TryListConversion(Sema &S, InitListExpr *From, QualType ToType,
     //    - if the initializer list has no elements, the implicit conversion
     //      sequence is the identity conversion.
     else if (NumInits == 0) {
-      Result.setStandard();
-      Result.Standard.setAsIdentityConversion();
-      Result.Standard.setFromType(ToType);
-      Result.Standard.setAllToTypes(ToType);
+      Result.setAsIdentityConversion(ToType);
     }
     return Result;
   }

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -307,7 +307,7 @@ StandardConversionSequence::getNarrowingKind(ASTContext &Ctx,
     ToType = ET->getDecl()->getIntegerType();
 
   // Converting from capability to pointer/integral is always narrowing
-  if (FromType->isMemoryCapabilityType(Ctx) && !ToType->isMemoryCapabilityType(Ctx))
+  if (FromType->isCHERICapabilityType(Ctx) && !ToType->isCHERICapabilityType(Ctx))
     return NK_Type_Narrowing;
 
   switch (Second) {
@@ -2137,7 +2137,7 @@ BuildSimilarlyQualifiedPointerType(const Type *FromPtr,
   if (ToType->isObjCIdType() || ToType->isObjCQualifiedIdType()) 
     return ToType.getUnqualifiedType();
 
-  const bool FromIsCap = FromPtr->isMemoryCapabilityType(Context);
+  const bool FromIsCap = FromPtr->isCHERICapabilityType(Context);
   ASTContext::PointerInterpretationKind PIK =
       FromIsCap ? ASTContext::PIK_Capability : ASTContext::PIK_Integer;
   QualType CanonFromPointee
@@ -2152,7 +2152,7 @@ BuildSimilarlyQualifiedPointerType(const Type *FromPtr,
   if (CanonToPointee.getLocalQualifiers() == Quals) {
     // ToType is exactly what we need. Return it.
     // XXXAR: but only if the memory capability qualifier matches
-    if (ToType->isMemoryCapabilityType(Context) == FromIsCap && !ToType.isNull())
+    if (ToType->isCHERICapabilityType(Context) == FromIsCap && !ToType.isNull())
       return ToType.getUnqualifiedType();
 
     // Build a pointer to ToPointee. It has the right qualifiers
@@ -2280,8 +2280,8 @@ bool Sema::IsPointerConversion(Expr *From, QualType FromType, QualType ToType,
                                                        ToPointeeType,
                                                        ToType, Context,
                                                    /*StripObjCLifetime=*/true);
-    assert(FromType->isMemoryCapabilityType(Context) ==
-           ConvertedType->isMemoryCapabilityType(Context) &&
+    assert(FromType->isCHERICapabilityType(Context) ==
+           ConvertedType->isCHERICapabilityType(Context) &&
            "Converted type should retain capability/pointer");
     return true;
   }

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -6956,7 +6956,7 @@ static bool HandleMemoryAddressAttr(QualType &T, TypeProcessingState &State,
     return true;
   }
 
-  if (!T->isIntegerType() || T->isMemoryCapabilityType(S.Context)) {
+  if (!T->isIntegerType() || T->isCHERICapabilityType(S.Context)) {
     S.Diag(Attr.getLoc(), diag::err_attribute_address_integers_only)
       << Attr.getName() << T;
     return true;

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -6830,6 +6830,16 @@ static void HandleCHERICapabilityAttr(QualType &CurType, TypeProcessingState &st
   Declarator &declarator = state.getDeclarator();
   Sema& S = state.getSema();
 
+  if (TAL == TAL_DeclName) {
+    // TODO: we should use the spelling as written in the source
+    // StringRef Name = attr.getName()->getName();
+    StringRef Name = "__capability";
+    S.Diag(attr.getLoc(), diag::err_attr_wrong_position) << Name
+        << FixItHint::CreateRemoval(attr.getLoc())
+        << FixItHint::CreateInsertion(state.getDeclarator().getName().getLocStart(), Name);
+    return;
+  }
+
   if (TAL == TAL_DeclSpec) {
     // possible deprecated use; move to the outermost pointer declarator
     // unless this is a typedef'd pointer type

--- a/lib/Sema/SemaType.cpp
+++ b/lib/Sema/SemaType.cpp
@@ -6946,7 +6946,6 @@ static bool HandleMemoryAddressAttr(QualType &T, TypeProcessingState &State,
     return true;
   }
 
-  T.dump();
   if (!T->isIntegerType() || T->isMemoryCapabilityType(S.Context)) {
     S.Diag(Attr.getLoc(), diag::err_attribute_address_integers_only)
       << Attr.getName() << T;

--- a/test/CodeGen/cheri-cast.c
+++ b/test/CodeGen/cheri-cast.c
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,HYBRID -enable-var-scope
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi purecap - %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,PURECAP -enable-var-scope
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -DWITH_CHERI_CAST %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,HYBRID -enable-var-scope
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -DWITH_CHERI_CAST -target-abi purecap %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,PURECAP -enable-var-scope
+
+
+extern void* global_ptr;
+extern void* __capability global_cap;
+
+#ifdef WITH_CHERI_CAST
+#define CHERI_CAST __cheri_cast
+#else
+#define CHERI_CAST
+#endif
+
+void* __capability c_cast_add_cap(void) {
+  void* __capability ptr2cap = (CHERI_CAST void* __capability)global_ptr;
+  return ptr2cap;
+
+  // HYBRID-LABEL: define i8 addrspace(200)* @c_cast_add_cap()
+  // HYBRID: [[GLOBAL:%.+]] = load i8*, i8** @global_ptr, align 8
+  // HYBRID-NEXT: [[RETVAL:%.+]] = addrspacecast i8* [[GLOBAL]] to i8 addrspace(200)*
+  // HYBRID-NEXT: ret i8 addrspace(200)* [[RETVAL]]
+
+  // PURECAP-LABEL: define i8 addrspace(200)* @c_cast_add_cap()
+  // PURECAP: [[RETVAL:%.+]] = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* @global_ptr, align 32
+  // PURECAP-NEXT: ret i8 addrspace(200)* [[RETVAL]]
+}
+
+void* c_cast_remove_cap(void) {
+  void* cap2ptr = (CHERI_CAST void*)global_cap;
+  return cap2ptr;
+  // HYBRID-LABEL: define i8* @c_cast_remove_cap()
+  // HYBRID: [[GLOBAL:%.+]] = load i8 addrspace(200)*, i8 addrspace(200)** @global_cap, align 32
+  // HYBRID-NEXT: [[RETVAL:%.+]] = addrspacecast i8 addrspace(200)* [[GLOBAL]] to i8*
+  // HYBRID-NEXT: ret i8* [[RETVAL]]
+
+  // PURECAP-LABEL: define i8 addrspace(200)* @c_cast_remove_cap()
+  // PURECAP: [[RETVAL:%.+]] = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* @global_cap, align 32
+  // PURECAP-NEXT: ret i8 addrspace(200)* [[RETVAL]]
+}

--- a/test/CodeGen/cheri-cast.c
+++ b/test/CodeGen/cheri-cast.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple cheri-unknown-freebsd %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,HYBRID -enable-var-scope
-// RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi purecap - %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,PURECAP -enable-var-scope
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd %s -Wno-error=cheri-capability-misuse -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,HYBRID -enable-var-scope
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -Wno-error=cheri-capability-misuse -target-abi purecap - %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,PURECAP -enable-var-scope
 // RUN: %clang_cc1 -triple cheri-unknown-freebsd -DWITH_CHERI_CAST %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,HYBRID -enable-var-scope
 // RUN: %clang_cc1 -triple cheri-unknown-freebsd -DWITH_CHERI_CAST -target-abi purecap %s -emit-llvm -o - -O2 | FileCheck %s -check-prefixes BOTH,PURECAP -enable-var-scope
 

--- a/test/CodeGen/cheri-pointer-interpretation-call.c
+++ b/test/CodeGen/cheri-pointer-interpretation-call.c
@@ -26,6 +26,6 @@ void *bar(void *a, void *b)
 	baz(a, b);
 	// CHECK: call chericcallcc i8 addrspace(200)* bitcast (i8* (i8 addrspace(200)*, i8 addrspace(200)*, i64, i8*, i8*)* @cheri_invoke to i8 addrspace(200)* (i8 addrspace(200)*, i8 addrspace(200)*, i64, i8 addrspace(200)*, i8 addrspace(200)*)*)(i8 addrspace(200)* inreg %{{.*}}, i8 addrspace(200)* inreg %{{.*}}, i64 zeroext %{{.*}}, i8 addrspace(200)* %{{.*}}, i8 addrspace(200)* %{{.*}})
 	// CHECK:  %{{.*}} = addrspacecast i8 addrspace(200)* %call2 to i8*
-	return (void*)foo((__capability void*)a, (__capability void*)b);
+	return (__cheri_cast void*)foo((__capability void*)a, (__capability void*)b);
 }
 

--- a/test/Misc/warning-flags.c
+++ b/test/Misc/warning-flags.c
@@ -100,4 +100,4 @@ CHECK-NEXT:   warn_weak_import
 
 The list of warnings in -Wpedantic should NEVER grow.
 
-CHECK: Number in -Wpedantic (not covered by other -W flags): 29
+CHECK: Number in -Wpedantic (not covered by other -W flags): 28

--- a/test/Misc/warning-flags.c
+++ b/test/Misc/warning-flags.c
@@ -100,4 +100,4 @@ CHECK-NEXT:   warn_weak_import
 
 The list of warnings in -Wpedantic should NEVER grow.
 
-CHECK: Number in -Wpedantic (not covered by other -W flags): 27
+CHECK: Number in -Wpedantic (not covered by other -W flags): 29

--- a/test/Sema/cheri-brace-init.c
+++ b/test/Sema/cheri-brace-init.c
@@ -8,8 +8,7 @@ struct foo {
 };
 
 void test_cap_to_ptr(void* __capability a) {
-  void* non_cap = a; // expected-error {{initializing 'void *' with an expression of incompatible type 'void * __capability'}}
-  // TODO: These should warn as well
+  void* non_cap = a; // expected-error {{converting capability type 'void * __capability' to pointer type 'void *' without an explicit cast}}
   struct foo f = {a, a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
   struct foo f2;
   f2 = (struct foo){a, NULL}; // this is fine
@@ -30,7 +29,7 @@ void test_arrays(void* __capability cap) {
   void* ptr_array3[3] = { [0 ... 2] = cap }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
   // TODO: this should probably warn about pointer -> cap conversion
 
-  void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{initializing 'void * __capability' with an expression of incompatible type 'int *'}}
+  void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{converting pointer type 'int *' to capability type 'void * __capability' without an explicit cast}}
 
   struct foo foo_array[5] = {
       {cap, NULL}, // no-error

--- a/test/Sema/cheri-brace-init.c
+++ b/test/Sema/cheri-brace-init.c
@@ -31,6 +31,13 @@ void test_arrays(void* __capability cap) {
   // TODO: this should probably warn about pointer -> cap conversion
 
   void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{initializing 'void * __capability' with an expression of incompatible type 'int *'}}
+
+  struct foo foo_array[5] = {
+      {cap, NULL}, // no-error
+      {cap, cap}, // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+      {.cap = NULL, .ptr = NULL}, // no-error
+      [4] = {.cap = cap, .ptr = cap} // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  };
 }
 
 union foo_union {

--- a/test/Sema/cheri-brace-init.c
+++ b/test/Sema/cheri-brace-init.c
@@ -12,7 +12,7 @@ struct foo {
 };
 
 void test_cap_to_ptr(void* __capability a) {
-  void* non_cap = a; // expected-error {{converting capability type 'void * __capability' to pointer type 'void *' without an explicit cast}}
+  void* non_cap = a; // expected-error {{converting capability type 'void * __capability' to non-capability type 'void *' without an explicit cast}}
   struct foo f = {a, a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
   struct foo f2;
   f2 = (struct foo){a, NULL}; // this is fine
@@ -33,7 +33,7 @@ void test_arrays(void* __capability cap) {
   void* ptr_array3[3] = { [0 ... 2] = cap }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
   // TODO: this should probably warn about pointer -> cap conversion
 
-  void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{converting pointer type 'int *' to capability type 'void * __capability' without an explicit cast}}
+  void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{converting non-capability type 'int *' to capability type 'void * __capability' without an explicit cast}}
 
   struct foo foo_array[5] = {
       {cap, NULL}, // no-error

--- a/test/Sema/cheri-brace-init.c
+++ b/test/Sema/cheri-brace-init.c
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c11 -o - %s -fsyntax-only -verify
+
+#define NULL ((void*)0)
+// These warnings only happen in the hybrid ABI
+struct foo {
+  void* __capability cap;
+  void* ptr;
+};
+
+void test_cap_to_ptr(void* __capability a) {
+  void* non_cap = a; // expected-error {{initializing 'void *' with an expression of incompatible type 'void * __capability'}}
+  // TODO: These should warn as well
+  struct foo f = {a, a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  struct foo f2;
+  f2 = (struct foo){a, NULL}; // this is fine
+  f2 = (struct foo){a, a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  struct foo f3 = {NULL, NULL};
+
+  // C99 designated initializer:
+  struct foo f4 = { .cap = a, .ptr = NULL};
+  struct foo f5 = { .cap = a, .ptr = a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+}
+
+// check arrays:
+void test_arrays(void* __capability cap) {
+  int* ptr = NULL;
+  void* ptr_array[3] = { NULL, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  // GCC range init:
+  void* ptr_array2[3] = { [0 ... 1] = NULL, cap }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  void* ptr_array3[3] = { [0 ... 2] = cap }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  // TODO: this should probably warn about pointer -> cap conversion
+
+  void* __capability cap_array[3] = { NULL, cap, ptr };  // expected-error {{initializing 'void * __capability' with an expression of incompatible type 'int *'}}
+}
+
+union foo_union {
+  void* ptr;
+  long l;
+};
+
+void test_union(void* __capability a) {
+  union foo_union u = {a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  u = (union foo_union){a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  union foo_union u2 = {.ptr = a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  union foo_union u3 = {.l = a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'long' in initializer list}}
+}

--- a/test/Sema/cheri-cap-ptr-casts.c
+++ b/test/Sema/cheri-cap-ptr-casts.c
@@ -10,12 +10,12 @@ void f() {
 void g() {
   __capability char *x;
   // CHECK: CStyleCastExpr {{.*}} {{.*}} 'char *' <CHERICapabilityToPointer>
-  char *y = (char *)x;
+  char *y = (__cheri_cast char *)x;
 }
 
 void h() {
   char *x;
   // CHECK: CStyleCastExpr {{.*}} {{.*}} 'char * __capability' <PointerToCHERICapability>
-  __capability char *y = (__capability char *)x;
+  __capability char *y = (__cheri_cast char * __capability)x;
 }
 #endif

--- a/test/Sema/cheri-cap-ptr-casts.c
+++ b/test/Sema/cheri-cap-ptr-casts.c
@@ -4,11 +4,11 @@
 #ifdef ALIGN
 void f() {
   unsigned long foo[8];
-  ((int * __capability *)foo)[0] = 0; // expected-error {{cast from 'unsigned long *' to 'int * __capability *' increases required alignment from 8 to 32}}
+  ((int * __capability *)foo)[0] = 0; // expected-error {{cast from 'unsigned long *' to 'int * __capability *' increases required alignment from 8 to 32}} expected-note{{use __builtin_assume_aligned(..., sizeof(void* __capability)) if you know that the source type is sufficiently aligned}}
 }
 #else
 void g() {
-  __capability char *x;
+  char * __capability x;
   // CHECK: CStyleCastExpr {{.*}} {{.*}} 'char *' <CHERICapabilityToPointer>
   char *y = (__cheri_cast char *)x;
 }
@@ -16,6 +16,6 @@ void g() {
 void h() {
   char *x;
   // CHECK: CStyleCastExpr {{.*}} {{.*}} 'char * __capability' <PointerToCHERICapability>
-  __capability char *y = (__cheri_cast char * __capability)x;
+  char * __capability y = (__cheri_cast char * __capability)x;
 }
 #endif

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -62,9 +62,11 @@ typedef __PTRDIFF_TYPE__ ptrdiff_t;
 typedef __uintcap_t uintptr_t;
 typedef __intcap_t intptr_t;
 typedef uintptr_t word;
+struct test {
+  int x;
+};
 
-void foo()
-{
+void foo(void) {
   unsigned long x1 = (unsigned long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'unsigned long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
   long x2 = (long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
   int x3 = (int)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'int' is most likely an error}} expected-note{{insert cast to vaddr_t}}
@@ -86,4 +88,17 @@ void foo()
 #ifndef __CHERI_PURE_CAPABILITY__
   word* x17 = (word*)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{insert cast to vaddr_t}}
 #endif
+}
+
+void test_cheri_cast(void) {
+  // __cheri_cast is a noop in pure ABI (but we still validate the parameter types)
+  char c;
+  struct test t;
+  struct test *tptr;
+  int * x = 0;
+  (__cheri_cast char*)x; // expected-error{{invalid __cheri_cast from 'int *' to unrelated type 'char *'}}
+  (__cheri_cast struct test*)t; // expected-error{{invalid source type 'struct test' for __cheri_cast: source must be a capability or a pointer}}
+  (__cheri_cast struct test)tptr; // expected-error{{invalid target type 'struct test' for __cheri_cast: target must be a capability or a pointer}}
+  (__cheri_cast struct test*)tptr; // this one is fine
+  // TODO: warn in hybrid mode if cast is a noop (it will always be in purecap mode but we accept it so that both compile)
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -108,5 +108,9 @@ void test_cheri_cast(void) {
 #ifndef __CHERI_PURE_CAPABILITY__
   // expected-warning@-2 {{__cheri_cast from 'struct test *' to 'struct test *' is a noop}}
 #endif
+
   int* __capability intptr_to_cap = (__cheri_cast int* __capability)x;
+  const int* __capability const_intcap = (__cheri_cast int* __capability)x;
+  (__cheri_cast int* __capability)const_intcap; // expected-error{{invalid __cheri_cast from 'const int * __capability' to unrelated type 'int * __capability'}}
+
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -117,7 +117,7 @@ void foo(void) {
   // AST: CStyleCastExpr {{.+}} 'long __attribute__((memory_address))':'long' <PointerToIntegral>
 
 #ifndef __CHERI_PURE_CAPABILITY__
-  word* x17 = (word*)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
+  word* x17 = (word*)a; // expected-error {{cast from capability type 'void * __capability' to integer pointer type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
   // AST: CStyleCastExpr {{.+}} 'word *' <CHERICapabilityToPointer>
 #endif
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -117,7 +117,7 @@ void foo(void) {
   // AST: CStyleCastExpr {{.+}} 'long __attribute__((memory_address))':'long' <PointerToIntegral>
 
 #ifndef __CHERI_PURE_CAPABILITY__
-  word* x17 = (word*)a; // expected-error {{cast from capability type 'void * __capability' to integer pointer type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
+  word* x17 = (word*)a; // expected-error {{cast from capability type 'void * __capability' to non-capability type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
   // AST: CStyleCastExpr {{.+}} 'word *' <CHERICapabilityToPointer>
 #endif
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -117,7 +117,7 @@ void foo(void) {
   // AST: CStyleCastExpr {{.+}} 'long __attribute__((memory_address))':'long' <PointerToIntegral>
 
 #ifndef __CHERI_PURE_CAPABILITY__
-  word* x17 = (word*)a; // expected-error {{cast from capability type 'void * __capability' to non-capability type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
+  word* x17 = (word*)a; // expected-error {{cast from capability type 'void * __capability' to non-capability type 'word *' (aka '__uintcap_t *') is most likely an error}}
   // AST: CStyleCastExpr {{.+}} 'word *' <CHERICapabilityToPointer>
 #endif
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -17,9 +17,9 @@
 void* __capability a;
 typedef __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__ vaddr_t;
 typedef __attribute__((memory_address)) vaddr_t double_attribute;  // expected-warning {{attribute 'memory_address' is already applied}}
-typedef __attribute__((memory_address)) __intcap_t err_cap_type;  // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('__intcap_t' is invalid)}}
-typedef __attribute__((memory_address)) struct foo err_struct_type; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('struct foo' is invalid)}}
-typedef int* __attribute__((memory_address)) err_pointer_type; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses}}
+typedef __attribute__((memory_address)) __intcap_t err_cap_type;  // expected-error {{'memory_address' attribute only applies to integer types that can store addresses ('__intcap_t' is invalid)}}
+typedef __attribute__((memory_address)) struct foo err_struct_type; // expected-error {{'memory_address' attribute only applies to integer types that can store addresses ('struct foo' is invalid)}}
+typedef int* __attribute__((memory_address)) err_pointer_type; // expected-error {{'memory_address' attribute only applies to integer types that can store addresses}}
 
 // seems like an attribute at the end is handled differently
 // FIXME: unless I make this an error I get a crash in clang:

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -6,6 +6,11 @@
 #error "memory_address attribute not supported"
 #endif
 
+#if !__has_extension(__cheri_cast)
+#error "__cheri_cast feature should exist"
+#endif
+
+
 void* __capability a;
 typedef __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__ vaddr_t;
 typedef __attribute__((memory_address)) vaddr_t double_attribute;  // expected-warning {{attribute 'memory_address' is already applied}}

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -1,0 +1,89 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -o - %s -fsyntax-only -verify
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -o - %s -fsyntax-only -verify
+
+#if !__has_attribute(memory_address)
+#error "memory_address attribute not supported"
+#endif
+
+void* __capability a;
+typedef __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__ vaddr_t;
+typedef __attribute__((memory_address)) vaddr_t double_attribute;  // expected-warning {{attribute 'memory_address' is already applied}}
+typedef __attribute__((memory_address)) __intcap_t err_cap_type;  // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('__intcap_t' is invalid)}}
+typedef __attribute__((memory_address)) struct foo err_struct_type; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('struct foo' is invalid)}}
+typedef int* __attribute__((memory_address)) err_pointer_type; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('int *' is invalid)}}
+
+// seems like an attribute at the end is handled differently
+// FIXME: unless I make this an error I get a crash in clang:
+typedef unsigned __PTRDIFF_TYPE__ err_bad_location __attribute__((memory_address)); // expected-error {{'memory_address' type specifier must precede the declarator}}
+/*
+Assertion failed: ((attrs || DeclAttrs) && "no type attributes in the expected location!"), function fillAttributedTypeLoc, file /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp, line 4527.
+Program received signal SIGABRT, Aborted.
+0x000000081211435a in thr_kill () from /lib/libc.so.7
+(gdb) bt
+#0  0x000000081211435a in thr_kill () from /lib/libc.so.7
+#1  0x0000000812114346 in raise () from /lib/libc.so.7
+#2  0x00000008121142c9 in abort () from /lib/libc.so.7
+#3  0x000000081217af91 in __assert () from /lib/libc.so.7
+#4  0x0000000816e14732 in fillAttributedTypeLoc (TL=..., attrs=0x0, DeclAttrs=0x0)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp:4526
+#5  0x0000000816e2721f in (anonymous namespace)::TypeSpecLocFiller::VisitAttributedTypeLoc
+    (this=0x7fffffff70c8, TL=...)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp:4572
+#6  0x0000000816e15e9a in clang::TypeLocVisitor<(anonymous namespace)::TypeSpecLocFiller, void>::Visit (this=0x7fffffff70c8, TyLoc=...)
+    at /home/alr48/cheri/sources/llvm/tools/clang/include/clang/AST/TypeNodes.def:94
+#7  0x0000000816e145da in clang::Sema::GetTypeSourceInfoForDeclarator (this=0x818ce7000,
+    D=..., T=..., ReturnTypeInfo=0x0)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp:4915
+#8  0x0000000816e13d09 in GetFullTypeForDeclarator (state=..., declSpecType=...,
+    TInfo=0x0) at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp:4315
+#9  0x0000000816e0eab5 in clang::Sema::GetTypeForDeclarator (this=0x818ce7000, D=...,
+    S=0x818d15700)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaType.cpp:4335
+#10 0x00000008166d00ee in clang::Sema::HandleDeclarator (this=0x818ce7000, S=0x818d15700,
+    D=..., TemplateParamLists=...)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaDecl.cpp:4780
+#11 0x00000008166cfa8b in clang::Sema::ActOnDeclarator (this=0x818ce7000, S=0x818d15700,
+    D=...) at /home/alr48/cheri/sources/llvm/tools/clang/lib/Sema/SemaDecl.cpp:4579
+#12 0x00000008160cbbba in clang::Parser::ParseDeclarationAfterDeclaratorAndAttributes (
+    this=0x818c86000, D=..., TemplateInfo=..., FRI=0x0)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Parse/ParseDecl.cpp:1934
+#13 0x00000008160ca85c in clang::Parser::ParseDeclGroup (this=0x818c86000, DS=...,
+    Context=0, DeclEnd=0x7fffffffa1b8, FRI=0x0)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Parse/ParseDecl.cpp:1809
+#14 0x00000008160c5d67 in clang::Parser::ParseSimpleDeclaration (this=0x818c86000,
+    Context=0, DeclEnd=..., Attrs=..., RequireSemi=true, FRI=0x0)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Parse/ParseDecl.cpp:1541
+#15 0x00000008160c5acd in clang::Parser::ParseDeclaration (this=0x818c86000, Context=0,
+    DeclEnd=..., attrs=...)
+    at /home/alr48/cheri/sources/llvm/tools/clang/lib/Parse/ParseDecl.cpp:1486
+*/
+typedef const vaddr_t other_addr_t;
+typedef __PTRDIFF_TYPE__ ptrdiff_t;
+typedef __uintcap_t uintptr_t;
+typedef __intcap_t intptr_t;
+typedef uintptr_t word;
+
+void foo()
+{
+  unsigned long x1 = (unsigned long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'unsigned long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
+  long x2 = (long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
+  int x3 = (int)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'int' is most likely an error}} expected-note{{insert cast to vaddr_t}}
+  ptrdiff_t x4 = (ptrdiff_t)a;  // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'ptrdiff_t' (aka 'long') is most likely an error}} expected-note{{insert cast to vaddr_t}}
+  // These are okay
+  uintptr_t x5 = (uintptr_t)a;
+  intptr_t x6 = (intptr_t)a; 
+  __uintcap_t x7 = (__uintcap_t)a;
+  __intcap_t x8 = (__intcap_t)a; 
+
+  vaddr_t x10 = (vaddr_t)a;
+  other_addr_t x11 = (other_addr_t)a;
+  void* __capability x12 = (void* __capability)a;
+  int x13 = (int)(uintptr_t)a;
+  int x14 = (int)(vaddr_t)a;
+  word* __capability x15 = (word* __capability)a;
+  long x16 = (long __attribute__((memory_address)))a; // no warning
+
+#ifndef __CHERI_PURE_CAPABILITY__
+  word* x17 = (word*)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{insert cast to vaddr_t}}
+#endif
+}

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -110,7 +110,7 @@ void foo(void) {
 
 #ifndef __CHERI_PURE_CAPABILITY__
   word* x17 = (word*)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'word *' (aka '__uintcap_t *') is most likely an error}} expected-note{{use __cheri_cast to convert between pointers and capabilities}}
-  // AST: CStyleCastExpr {{.+}} 'word *' <MemoryCapabilityToPointer>
+  // AST: CStyleCastExpr {{.+}} 'word *' <CHERICapabilityToPointer>
 #endif
 }
 
@@ -134,9 +134,9 @@ void test_cheri_cast(void) {
 #endif
 
   int* __capability intptr_to_cap = (__cheri_cast int* __capability)x;
-  // AST: CStyleCastExpr {{.+}} 'int * __capability' <PointerToMemoryCapability>
+  // AST: CStyleCastExpr {{.+}} 'int * __capability' <PointerToCHERICapability>
   const int* __capability const_intcap = (__cheri_cast int* __capability)x;
   // AST: ImplicitCastExpr {{.+}} 'const int * __capability' <BitCast>
-  // AST-NEXT: CStyleCastExpr {{.+}} 'int * __capability' <PointerToMemoryCapability>
+  // AST-NEXT: CStyleCastExpr {{.+}} 'int * __capability' <PointerToCHERICapability>
   (__cheri_cast int* __capability)const_intcap; // expected-error{{invalid __cheri_cast from 'const int * __capability' to unrelated type 'int * __capability'}}
 }

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -2,6 +2,9 @@
 // RUN: not %clang_cc1 -triple cheri-unknown-freebsd -o - %s -fsyntax-only -ast-dump | FileCheck %s -check-prefix AST
 // RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi purecap -o - %s -fsyntax-only -verify
 
+#pragma clang diagnostic warning "-Wcapability-to-integer-cast"
+#pragma clang diagnostic warning "-Wpedantic"
+
 #if !__has_attribute(memory_address)
 #error "memory_address attribute not supported"
 #endif

--- a/test/Sema/cheri-cap-to-int-cast.c
+++ b/test/Sema/cheri-cap-to-int-cast.c
@@ -67,10 +67,10 @@ struct test {
 };
 
 void foo(void) {
-  unsigned long x1 = (unsigned long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'unsigned long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
-  long x2 = (long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}} expected-note{{insert cast to vaddr_t}}
-  int x3 = (int)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'int' is most likely an error}} expected-note{{insert cast to vaddr_t}}
-  ptrdiff_t x4 = (ptrdiff_t)a;  // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'ptrdiff_t' (aka 'long') is most likely an error}} expected-note{{insert cast to vaddr_t}}
+  unsigned long x1 = (unsigned long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'unsigned long' is most likely an error}}
+  long x2 = (long)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}}
+  int x3 = (int)a; // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'int' is most likely an error}}
+  ptrdiff_t x4 = (ptrdiff_t)a;  // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'ptrdiff_t' (aka 'long') is most likely an error}}
   // These are okay
   uintptr_t x5 = (uintptr_t)a;
   intptr_t x6 = (intptr_t)a; 

--- a/test/Sema/cheri-capability-qualifier-invalid.c
+++ b/test/Sema/cheri-capability-qualifier-invalid.c
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -DTYPEDEF -o - %s -fsyntax-only -verify
+
+// __capability after the name crashes -> make it an error
+
+struct foo;
+typedef struct foo* err1 __capability; // expected-error {{'__capability' type specifier must precede the declarator}}
+typedef int err2 __capability; // expected-error {{'__capability' type specifier must precede the declarator}}
+typedef __capability int err3; // expected-error {{__capability only applies to pointers; type here is 'int'}}
+typedef int __capability err4; // expected-error {{__capability only applies to pointers; type here is 'int'}}
+typedef __uintcap_t __capability err6;  // expected-error {{__capability only applies to pointers; type here is '__uintcap_t'}}
+
+
+void* a __capability; // expected-error {{'__capability' type specifier must precede the declarator}}
+// the original test case from  https://github.com/CTSRD-CHERI/clang/issues/134:
+__END_DECLS a __capability; // expected-error {{unknown type name '__END_DECLS'}} expected-error {{'__capability' type specifier must precede the declarator}}

--- a/test/Sema/cheri-implicit-casts.c
+++ b/test/Sema/cheri-implicit-casts.c
@@ -1,11 +1,11 @@
 // RUN: %cheri_cc1 %s -fsyntax-only -verify
 void f() {
   char * __capability x;
-  char *y = x; // expected-error {{converting capability type 'char * __capability' to pointer type 'char *' without an explicit cast}}
+  char *y = x; // expected-error {{converting capability type 'char * __capability' to non-capability type 'char *' without an explicit cast}}
 }
 void g() {
   char *x;
-  char * __capability y = x; // expected-error {{converting pointer type 'char *' to capability type 'char * __capability' without an explicit cast}}
+  char * __capability y = x; // expected-error {{converting non-capability type 'char *' to capability type 'char * __capability' without an explicit cast}}
 }
 void h() {
   char * __capability x;

--- a/test/Sema/cheri-implicit-casts.c
+++ b/test/Sema/cheri-implicit-casts.c
@@ -1,11 +1,11 @@
-// RUN: %clang_cc1 %s -triple cheri-unknown-freebsd -fsyntax-only -verify
+// RUN: %cheri_cc1 %s -fsyntax-only -verify
 void f() {
   char * __capability x;
-  char *y = x; // expected-error {{initializing 'char *' with an expression of incompatible type 'char * __capability'}}
+  char *y = x; // expected-error {{converting capability type 'char * __capability' to pointer type 'char *' without an explicit cast}}
 }
 void g() {
   char *x;
-  char * __capability y = x; // expected-error {{initializing 'char * __capability' with an expression of incompatible type 'char *'}}
+  char * __capability y = x; // expected-error {{converting pointer type 'char *' to capability type 'char * __capability' without an explicit cast}}
 }
 void h() {
   char * __capability x;

--- a/test/Sema/cheri-int-to-cap-cast.c
+++ b/test/Sema/cheri-int-to-cap-cast.c
@@ -4,5 +4,9 @@ void * __capability c;
 void a(int x, long long y)
 {
 	b = (void * __capability)x; // expected-warning {{cast to 'void * __capability' from smaller integer type 'int'}}
+	// expected-warning@-1 {{cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced}}
+	// expected-note@-2 {{insert cast to intptr_t to silence this warning}}
 	c = (void * __capability)y; // Should be no warning here - long long is 64 bits.
+	// expected-warning@-1 {{cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced}}
+	// expected-note@-2 {{insert cast to intptr_t to silence this warning}}
 }

--- a/test/Sema/cheri_atomic_builtins.c
+++ b/test/Sema/cheri_atomic_builtins.c
@@ -38,7 +38,7 @@
 int capability_ptr() {
   void* __capability foo_cap;
   void* __capability result = 0;
-  void* __capability newval = (void* __capability)&foo_cap;
+  void* __capability newval = (__cheri_cast void* __capability * __capability)&foo_cap;
   do_atomic_ops(&foo_cap, result, newval); // expected-error 16 {{the __sync_* atomic builtins only work with integers and not capability type 'void * __capability'.}}
   // check that calling the size-suffixed functions fails too
   do_suffixed_atomic_ops(&foo_cap, result, newval); // expected-error 5 {{the __sync_* atomic builtins only work with integers and not capability type 'void * __capability'.}}

--- a/test/SemaCXX/cheri-brace-init.cpp
+++ b/test/SemaCXX/cheri-brace-init.cpp
@@ -97,7 +97,7 @@ void test_capref_to_ptrref(int& __capability a) {
 void test_arrays(void* __capability cap) {
   int* ptr = nullptr;
   void* ptr_array[3] = { nullptr, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
-  void* __capability cap_array[3] = { nullptr, cap, ptr }; // expected-error {{cannot initialize an array element of type 'void * __capability' with an lvalue of type 'int *'}}
+  void* __capability cap_array[3] = { nullptr, cap, ptr }; // expected-error {{converting pointer type 'int *' to capability type 'void * __capability' without an explicit cast}}
 
     struct foo foo_array[5] = {
       {cap, nullptr}, // no-error

--- a/test/SemaCXX/cheri-brace-init.cpp
+++ b/test/SemaCXX/cheri-brace-init.cpp
@@ -1,0 +1,113 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -o - %s -fsyntax-only -verify
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -target-abi purecap -o - %s -fsyntax-only -verify
+
+#if !__has_attribute(memory_address)
+#error "memory_address attribute not supported"
+#endif
+
+using vaddr_t = __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__;
+
+struct test {
+  int x;
+};
+
+void test_capptr_to_int(void* __capability a) {
+  vaddr_t v{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'vaddr_t' (aka 'unsigned long') in initializer list}}
+  v = vaddr_t{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'vaddr_t' (aka 'unsigned long') in initializer list}}
+  vaddr_t v2 = 0; v2 = {a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'vaddr_t' (aka 'unsigned long') in initializer list}}
+
+  __uintcap_t uc{a}; // expected-error {{cannot initialize a variable of type '__uintcap_t' with an lvalue of type 'void * __capability'}}
+  uc = __uintcap_t{a};  // expected-error {{cannot initialize a value of type '__uintcap_t' with an lvalue of type 'void * __capability'}}
+  __uintcap_t uc2 = 0; uc2 = {a}; // expected-error {{cannot initialize a value of type '__uintcap_t' with an lvalue of type 'void * __capability'}}
+
+  __intcap_t ic{a}; // expected-error {{cannot initialize a variable of type '__intcap_t' with an lvalue of type 'void * __capability'}}
+  ic = __intcap_t{a};  // expected-error {{cannot initialize a value of type '__intcap_t' with an lvalue of type 'void * __capability'}}
+  __intcap_t ic2 = 0; ic2 = {a}; // expected-error {{cannot initialize a value of type '__intcap_t' with an lvalue of type 'void * __capability'}}
+
+  long l{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'long' in initializer list}}
+  l = long{a};  // expected-error {{type 'void * __capability' cannot be narrowed to 'long' in initializer list}}
+  long l2 = 0; l2 = {a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'long' in initializer list}}
+
+  int i{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'int' in initializer list}}
+  i = int{a};  // expected-error {{type 'void * __capability' cannot be narrowed to 'int' in initializer list}}
+  int i2 = 0; i2 = {a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'int' in initializer list}}
+}
+
+void test_uintcap_to_int(__uintcap_t a) {
+  vaddr_t v{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'vaddr_t'}}
+  v = vaddr_t{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'vaddr_t'}}
+  vaddr_t v2 = 0; v2 = {a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'vaddr_t'}}
+
+  long l{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'long'}}
+  l = long{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'long'}}
+  long l2 = 0; l2 = {a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'long'}}
+
+  int i{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'int'}}
+  i = int{a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'int'}}
+  int i2 = 0; i2 = {a}; // expected-error {{'__uintcap_t' cannot be narrowed to 'int'}}
+
+  __uintcap_t uc{a};
+  uc = __uintcap_t{a};
+  __uintcap_t uc2 = 0; uc2 = {a};
+
+  __intcap_t ic{a}; // expected-error {{non-constant-expression cannot be narrowed from type '__uintcap_t' to '__intcap_t'}} expected-note {{insert an explicit cast to silence this issue}}
+  ic = __intcap_t{a}; // expected-error {{non-constant-expression cannot be narrowed from type '__uintcap_t' to '__intcap_t'}} expected-note {{insert an explicit cast to silence this issue}}
+  __intcap_t ic2 = 0; ic2 = {a}; // expected-error {{non-constant-expression cannot be narrowed from type '__uintcap_t' to '__intcap_t'}} expected-note {{insert an explicit cast to silence this issue}}
+
+}
+
+// These warnings only happen in the hybrid ABI
+#ifndef __CHERI_PURE_CAPABILITY__
+
+struct foo {
+  void* __capability cap;
+  void* ptr;
+};
+
+void test_cap_to_ptr(void* __capability a) {
+  void* non_cap{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  void* non_cap2 = {a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  // TODO: These should warn as well
+  foo f{a, a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  foo f2;
+  f2 = {a, nullptr}; // this is fine
+  // TODO: it would be nice if we could get a better error message here (see SemaOverload.cpp), it works fine for references
+  f2 = {a, a}; // expected-error {{no viable overloaded '='}}
+  // expected-note@-14 {{candidate function (the implicit copy assignment operator) not viable: cannot convert initializer list argument to 'const foo'}}
+  // expected-note@-15 {{candidate function (the implicit move assignment operator) not viable: cannot convert initializer list argument to 'foo'}}
+  foo f3{nullptr, nullptr};
+}
+
+struct foo2 {
+  int& __capability cap;
+  int& ptr;
+};
+
+void test_capref_to_ptrref(int& __capability a) {
+  int i = 0;
+  int& __capability cap_ref = i;
+  int& non_cap{a}; // todo-expected-error {{cap_to_int}}
+  int& non_cap2 = {a}; // todo-expected-error {{cap_to_int}}
+  foo2 f{a, a}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
+  foo2 f2 = {a, a}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
+  foo2 f3 = {cap_ref, cap_ref}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
+}
+
+// check arrays:
+void test_arrays(void* __capability cap) {
+  int* ptr = nullptr;
+  void* ptr_array[3] = { nullptr, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  // TODO: this should probably warn about pointer -> cap conversion
+  void* __capability cap_array[3] = { nullptr, cap, ptr };
+}
+
+union foo_union {
+  void* ptr;
+  long l;
+};
+
+void test_union(void* __capability a) {
+  foo_union u{a}; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+}
+
+#endif

--- a/test/SemaCXX/cheri-brace-init.cpp
+++ b/test/SemaCXX/cheri-brace-init.cpp
@@ -97,8 +97,7 @@ void test_capref_to_ptrref(int& __capability a) {
 void test_arrays(void* __capability cap) {
   int* ptr = nullptr;
   void* ptr_array[3] = { nullptr, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
-  // TODO: this should probably warn about pointer -> cap conversion
-  void* __capability cap_array[3] = { nullptr, cap, ptr };
+  void* __capability cap_array[3] = { nullptr, cap, ptr }; // expected-error {{cannot initialize an array element of type 'void * __capability' with an lvalue of type 'int *'}}
 
     struct foo foo_array[5] = {
       {cap, nullptr}, // no-error

--- a/test/SemaCXX/cheri-brace-init.cpp
+++ b/test/SemaCXX/cheri-brace-init.cpp
@@ -78,26 +78,12 @@ void test_cap_to_ptr(void* __capability a) {
   foo f3{nullptr, nullptr};
 }
 
-struct foo2 {
-  int& __capability cap;
-  int& ptr;
-};
-
-void test_capref_to_ptrref(int& __capability a) {
-  int i = 0;
-  int& __capability cap_ref = i;
-  int& non_cap{a}; // todo-expected-error {{cap_to_int}}
-  int& non_cap2 = {a}; // todo-expected-error {{cap_to_int}}
-  foo2 f{a, a}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
-  foo2 f2 = {a, a}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
-  foo2 f3 = {cap_ref, cap_ref}; // expected-error {{type 'int & __capability' cannot be narrowed to 'int &' in initializer list}}
-}
 
 // check arrays:
 void test_arrays(void* __capability cap) {
   int* ptr = nullptr;
   void* ptr_array[3] = { nullptr, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
-  void* __capability cap_array[3] = { nullptr, cap, ptr }; // expected-error {{converting pointer type 'int *' to capability type 'void * __capability' without an explicit cast}}
+  void* __capability cap_array[3] = { nullptr, cap, ptr }; // expected-error {{converting non-capability type 'int *' to capability type 'void * __capability' without an explicit cast}}
 
     struct foo foo_array[5] = {
       {cap, nullptr}, // no-error

--- a/test/SemaCXX/cheri-brace-init.cpp
+++ b/test/SemaCXX/cheri-brace-init.cpp
@@ -99,6 +99,13 @@ void test_arrays(void* __capability cap) {
   void* ptr_array[3] = { nullptr, cap, ptr }; // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
   // TODO: this should probably warn about pointer -> cap conversion
   void* __capability cap_array[3] = { nullptr, cap, ptr };
+
+    struct foo foo_array[5] = {
+      {cap, nullptr}, // no-error
+      {cap, cap}, // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+      {.cap = nullptr, .ptr = nullptr}, // no-error
+      [4] = {.cap = cap, .ptr = cap} // expected-error {{type 'void * __capability' cannot be narrowed to 'void *' in initializer list}}
+  };
 }
 
 union foo_union {

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -15,9 +15,9 @@
 void* __capability a;
 using vaddr_t = __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__;
 using double_attribute = __attribute__((memory_address)) vaddr_t;  // expected-warning {{attribute 'memory_address' is already applied}}
-using err_cap_type = __attribute__((memory_address)) __intcap_t;  // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('__intcap_t' is invalid)}}
-using err_struct_type = __attribute__((memory_address)) struct foo; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('struct foo' is invalid)}}
-using err_pointer_type = int* __attribute__((memory_address)); // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses}}
+using err_cap_type = __attribute__((memory_address)) __intcap_t;  // expected-error {{'memory_address' attribute only applies to integer types that can store addresses ('__intcap_t' is invalid)}}
+using err_struct_type = __attribute__((memory_address)) struct foo; // expected-error {{'memory_address' attribute only applies to integer types that can store addresses ('struct foo' is invalid)}}
+using err_pointer_type = int* __attribute__((memory_address)); // expected-error {{'memory_address' attribute only applies to integer types that can store addresses}}
 
 typedef const vaddr_t other_addr_t;
 typedef __PTRDIFF_TYPE__ ptrdiff_t;

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -5,6 +5,10 @@
 #error "memory_address attribute not supported"
 #endif
 
+#if !__has_extension(__cheri_cast)
+#error "__cheri_cast feature should exist"
+#endif
+
 void* __capability a;
 using vaddr_t = __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__;
 using double_attribute = __attribute__((memory_address)) vaddr_t;  // expected-warning {{attribute 'memory_address' is already applied}}

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -o - %s -fsyntax-only -verify
 // RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -target-abi purecap -o - %s -fsyntax-only -verify
 
+#pragma clang diagnostic warning "-Wcapability-to-integer-cast"
+
+
 #if !__has_attribute(memory_address)
 #error "memory_address attribute not supported"
 #endif

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -164,16 +164,16 @@ void cast_ptr() {
 #endif
 }
 
-#ifdef NOTYET
 void cast_ref(int & __capability cap_ref) {
   int x;
   using intref = int&;
-  int& v = reinterpret_cast<int&>(cap_ref);
-  v = static_cast<int&>(cap_ref);
-  v = const_cast<int&>(cap_ref);
+  int& v = reinterpret_cast<int&>(cap_ref); // expected-error{{cast from capability type 'int & __capability' to non-capability type 'int &' is most likely an error}} expected-note {{use __cheri_cast to convert between pointers and capabilities}}
+  v = static_cast<int&>(cap_ref); // expected-error{{cast from capability type 'int & __capability' to non-capability type 'int &' is most likely an error}} expected-note {{use __cheri_cast to convert between pointers and capabilities}}
+  // FIXME: this error shouldn/t be there twice:
+  // expected-error@-2 {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+  v = const_cast<int&>(cap_ref); // expected-error{{cast from capability type 'int & __capability' to non-capability type 'int &' is most likely an error}} expected-note {{use __cheri_cast to convert between pointers and capabilities}}
   v = dynamic_cast<int&>(cap_ref); // expected-error{{'int' is not a class}}
-  v = (int&)cap_ref;
-  v = intref(cap_ref);
-  v = intref{cap_ref};
+  v = (int&)cap_ref; // expected-error{{cast from capability type 'int & __capability' to non-capability type 'int &' is most likely an error}} expected-note {{use __cheri_cast to convert between pointers and capabilities}}
+  v = intref(cap_ref); // expected-error{{cast from capability type 'int & __capability' to non-capability type 'intref' (aka 'int &') is most likely an error}} expected-note {{use __cheri_cast to convert between pointers and capabilities}}
+  v = intref{cap_ref}; // expected-error{{converting capability type 'int & __capability' to non-capability type 'intref' (aka 'int &') without an explicit cast}}
 }
-#endif

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -131,7 +131,7 @@ void cast_ptr() {
   using voidp = void*;
   DO_ALL_CASTS(voidp, a);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-2 5 {{cast from capability type 'void * __capability' to integer pointer type 'voidp' (aka 'void *') is most likely an error}}
+  // expected-error@-2 5 {{cast from capability type 'void * __capability' to non-capability type 'voidp' (aka 'void *') is most likely an error}}
   // expected-note@-3 5{{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{type 'void * __capability' cannot be narrowed to 'voidp' (aka 'void *') in initializer list}}
 #endif
@@ -141,7 +141,7 @@ void cast_ptr() {
   using wordp = word*;
   DO_ALL_CASTS(wordp, a);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-2 4 {{cast from capability type 'void * __capability' to integer pointer type 'wordp' (aka '__uintcap_t *') is most likely an error}}
+  // expected-error@-2 4 {{cast from capability type 'void * __capability' to non-capability type 'wordp' (aka '__uintcap_t *') is most likely an error}}
   // expected-note@-3 4 {{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{type 'void * __capability' cannot be narrowed to 'wordp' (aka '__uintcap_t *') in initializer list}}
   // expected-error@-5 {{const_cast from 'void * __capability' to 'wordp' (aka '__uintcap_t *') is not allowed}}
@@ -157,7 +157,7 @@ void cast_ptr() {
   test_class* __capability b = nullptr;
   DO_ALL_CASTS(test_class_ptr, b);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-2 5 {{cast from capability type 'test_class * __capability' to integer pointer type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
+  // expected-error@-2 5 {{cast from capability type 'test_class * __capability' to non-capability type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
   // expected-note@-3 5 {{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{test_class * __capability' cannot be narrowed to 'test_class_ptr' (aka 'test_class *') in initializer list}}
   // expected-error@-5 {{static_cast from 'test_class * __capability' to 'test_class_ptr' (aka 'test_class *'), which are not related by inheritance, is not allowed}} // TODO: this should be a better error message
@@ -165,19 +165,15 @@ void cast_ptr() {
 }
 
 #ifdef NOTYET
-
-void cast_ref() {
-  // XXXAR: these should also warn
+void cast_ref(int & __capability cap_ref) {
   int x;
-  int & __capability cap_ref = x;
-  using intr = int&;
+  using intref = int&;
   int& v = reinterpret_cast<int&>(cap_ref);
   v = static_cast<int&>(cap_ref);
   v = const_cast<int&>(cap_ref);
   v = dynamic_cast<int&>(cap_ref); // expected-error{{'int' is not a class}}
   v = (int&)cap_ref;
-  v = intr(cap_ref);
-  v = intr{cap_ref};
+  v = intref(cap_ref);
+  v = intref{cap_ref};
 }
-
 #endif

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -158,9 +158,8 @@ void cast_ptr() {
   DO_ALL_CASTS(test_class_ptr, b);
 #ifndef __CHERI_PURE_CAPABILITY__
   // expected-error@-2 5 {{cast from capability type 'test_class * __capability' to non-capability type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
-  // expected-note@-3 5 {{use __cheri_cast to convert between pointers and capabilities}}
-  // expected-error@-4 {{test_class * __capability' cannot be narrowed to 'test_class_ptr' (aka 'test_class *') in initializer list}}
-  // expected-error@-5 {{static_cast from 'test_class * __capability' to 'test_class_ptr' (aka 'test_class *'), which are not related by inheritance, is not allowed}} // TODO: this should be a better error message
+  // expected-error@-3 {{test_class * __capability' cannot be narrowed to 'test_class_ptr' (aka 'test_class *') in initializer list}}
+  // expected-error@-4 {{static_cast from 'test_class * __capability' to 'test_class_ptr' (aka 'test_class *'), which are not related by inheritance, is not allowed}} // TODO: this should be a better error message
 #endif
 }
 

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -1,0 +1,168 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -o - %s -fsyntax-only -verify
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -std=c++11 -target-abi purecap -o - %s -fsyntax-only -verify
+
+#if !__has_attribute(memory_address)
+#error "memory_address attribute not supported"
+#endif
+
+void* __capability a;
+using vaddr_t = __attribute__((memory_address)) unsigned __PTRDIFF_TYPE__;
+using double_attribute = __attribute__((memory_address)) vaddr_t;  // expected-warning {{attribute 'memory_address' is already applied}}
+using err_cap_type = __attribute__((memory_address)) __intcap_t;  // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('__intcap_t' is invalid)}}
+using err_struct_type = __attribute__((memory_address)) struct foo; // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses ('struct foo' is invalid)}}
+using err_pointer_type = int* __attribute__((memory_address)); // expected-error {{'memory_address' attribute only applies to integer types that can store memory addresses}}
+
+typedef const vaddr_t other_addr_t;
+typedef __PTRDIFF_TYPE__ ptrdiff_t;
+typedef __uintcap_t uintptr_t;
+typedef __intcap_t intptr_t;
+typedef uintptr_t word;
+struct test {
+  int x;
+};
+
+void cast_vaddr() {
+  // These casts should be fine, typedef with attribute
+  vaddr_t v = reinterpret_cast<vaddr_t>(a);
+  v = static_cast<vaddr_t>(a); // expected-error {{static_cast from 'void * __capability' to 'vaddr_t' (aka 'unsigned long') is not allowed}}
+  v = (vaddr_t)a;
+  v = vaddr_t(a);
+  v = vaddr_t{a}; // expected-error {{cannot initialize a value of type 'vaddr_t' (aka 'unsigned long') with an lvalue of type 'void * __capability'}}
+}
+
+void cast_vaddr2() {
+  // These casts should be fine, typedef with attribute
+  long __attribute__((memory_address)) v = reinterpret_cast<long __attribute__((memory_address))>(a);
+  v = static_cast<long __attribute__((memory_address))>(a); // expected-error {{static_cast from 'void * __capability' to 'long __attribute__((memory_address))' is not allowed}}
+  v = (long __attribute__((memory_address)))a;
+  // these won't work, need single token for functional/brace-init:
+  // v = long __attribute__((memory_address))(a);
+  // v = long __attribute__((memory_address)){a};
+
+  __attribute__((memory_address)) long v2 = reinterpret_cast<__attribute__((memory_address)) long>(a);
+  v2 = static_cast<__attribute__((memory_address)) long>(a); // expected-error {{static_cast from 'void * __capability' to 'long __attribute__((memory_address))' is not allowed}}
+  v2 = (__attribute__((memory_address)) long)a;
+}
+
+void cast_long() {
+  long v = reinterpret_cast<long>(a); // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}}
+  v = static_cast<long>(a);  // expected-error {{static_cast from 'void * __capability' to 'long' is not allowed}}
+  v = (long)a;  // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}}
+  v = long(a); // expected-warning {{cast from capability type 'void * __capability' to non-capability, non-address type 'long' is most likely an error}}
+  v = long{a}; // expected-error {{cannot initialize a value of type 'long' with an lvalue of type 'void * __capability'}}
+}
+
+
+// Should cause narrowing errors
+void cast_int() {
+  int v = reinterpret_cast<int>(a); // expected-error {{cast from capability to smaller type 'int' loses information}}
+  v = static_cast<int>(a);  // expected-error {{static_cast from 'void * __capability' to 'int' is not allowed}}
+  v = (int)a; // expected-error {{cast from capability to smaller type 'int' loses information}}
+  v = int(a); // expected-error {{cast from capability to smaller type 'int' loses information}}
+  v = int{a}; // expected-error {{cannot initialize a value of type 'int' with an lvalue of type 'void * __capability'}}
+}
+
+void cast_uintcap() {
+  __uintcap_t v = reinterpret_cast<__uintcap_t>(a);
+  // XXXAR: should we allow this static cast?
+  v = static_cast<__uintcap_t>(a); // expected-error {{static_cast from 'void * __capability' to '__uintcap_t' is not allowed}}
+  v = (__uintcap_t)a;
+  v = __uintcap_t(a);
+  v = __uintcap_t{a}; // expected-error {{cannot initialize a value of type '__uintcap_t' with an lvalue of type 'void * __capability'}}
+}
+
+void cast_to_cap(void) {
+  // noops that shouldn't warn
+  auto p1 = reinterpret_cast<void* __capability>(a); // no warning
+  auto p2 = (void* __capability)a; // no warning
+
+  auto w1 = reinterpret_cast<word* __capability>(a); // no warning
+  auto w2 = (word* __capability)a; // no warning
+}
+
+
+// Currently none of these warn: https://github.com/CTSRD-CHERI/clang/issues/140
+
+void probably_an_error(__uintcap_t* cap) {
+  long l = *cap;
+  l += 1;
+  *cap = l;
+}
+
+void check_uintcap_to_int() {
+  __uintcap_t cap;
+  int i = cap;
+  i = (int)cap;
+  i = int(cap);
+  i = int{cap};  // expected-error {{non-constant-expression cannot be narrowed from type '__uintcap_t' to 'int' in initializer list}} expected-note {{insert an explicit cast to silence this issue}}
+  i = static_cast<int>(cap);
+  long l = cap;
+  l = (long)cap;
+  l = long(cap);
+  l = long{cap}; // expected-error {{non-constant-expression cannot be narrowed from type '__uintcap_t' to 'long' in initializer list}} expected-note {{insert an explicit cast to silence this issue}}
+  l = static_cast<long>(cap);
+
+#ifndef NOTYET
+  i = reinterpret_cast<int>(cap);
+  l = reinterpret_cast<long>(cap);
+#endif
+}
+
+
+class test_class {};
+
+#define DO_ALL_CASTS(to, from) do { \
+  to var = reinterpret_cast<to>(from); \
+  var = static_cast<to>(from); \
+  var = const_cast<to>(from); \
+  var = dynamic_cast<to>(from); \
+  var = (to)from; \
+  var = to(from); \
+  var = to{from}; \
+} while(false)
+
+void cast_ptr() {
+  // XXXAR: these should also warn
+  using voidp = void*;
+  DO_ALL_CASTS(voidp, a);
+#ifndef __CHERI_PURE_CAPABILITY__
+  // expected-warning@-2 5 {{cast from capability type 'void * __capability' to non-capability, non-address type 'voidp' (aka 'void *') is most likely an error}}
+  // expected-note@-3 5{{use __cheri_cast to convert between pointers and capabilities}}
+  // not-yet-expected-error@-4 // narrowing init
+#endif
+  // expected-error@-6 {{'void' is not a class}}
+
+
+  using wordp = word*;
+  DO_ALL_CASTS(wordp, a);
+#ifndef __CHERI_PURE_CAPABILITY__
+  // expected-warning@-2 4 {{cast from capability type 'void * __capability' to non-capability, non-address type 'wordp' (aka '__uintcap_t *') is most likely an error}}
+  // expected-note@-3 4{{use __cheri_cast to convert between pointers and capabilities}}
+#endif
+  // expected-error-re@-5 {{cannot initialize a value of type 'wordp' (aka '__uintcap_t *{{( __capability)?}}') with an lvalue of type 'void * __capability'}}
+  // expected-error@-6 {{'__uintcap_t' is not a class}}
+  // expected-error@-7 {{const_cast from 'void * __capability' to 'wordp' (aka '__uintcap_t *') is not allowed}}
+
+
+  using test_class_ptr = test_class*;
+  test_class* __capability b = nullptr;
+  DO_ALL_CASTS(test_class_ptr, b);
+#ifndef __CHERI_PURE_CAPABILITY__
+  // expected-warning@-2 6 {{cast from capability type 'test_class * __capability' to non-capability, non-address type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
+  // expected-note@-3 6{{use __cheri_cast to convert between pointers and capabilities}}
+#endif
+}
+
+void cast_ref() {
+  // XXXAR: these should also warn
+  int x;
+  int & __capability cap_ref = x;
+  using intr = int&;
+  int& v = reinterpret_cast<int&>(cap_ref);
+  v = static_cast<int&>(cap_ref);
+  v = const_cast<int&>(cap_ref);
+  v = dynamic_cast<int&>(cap_ref); // expected-error{{'int' is not a class}}
+  v = (int&)cap_ref;
+  v = intr(cap_ref);
+  v = intr{cap_ref};
+}

--- a/test/SemaCXX/cheri-cap-to-int-cast.cpp
+++ b/test/SemaCXX/cheri-cap-to-int-cast.cpp
@@ -131,7 +131,7 @@ void cast_ptr() {
   using voidp = void*;
   DO_ALL_CASTS(voidp, a);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-warning@-2 5 {{cast from capability type 'void * __capability' to non-capability, non-address type 'voidp' (aka 'void *') is most likely an error}}
+  // expected-error@-2 5 {{cast from capability type 'void * __capability' to integer pointer type 'voidp' (aka 'void *') is most likely an error}}
   // expected-note@-3 5{{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{type 'void * __capability' cannot be narrowed to 'voidp' (aka 'void *') in initializer list}}
 #endif
@@ -141,7 +141,7 @@ void cast_ptr() {
   using wordp = word*;
   DO_ALL_CASTS(wordp, a);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-warning@-2 4 {{cast from capability type 'void * __capability' to non-capability, non-address type 'wordp' (aka '__uintcap_t *') is most likely an error}}
+  // expected-error@-2 4 {{cast from capability type 'void * __capability' to integer pointer type 'wordp' (aka '__uintcap_t *') is most likely an error}}
   // expected-note@-3 4 {{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{type 'void * __capability' cannot be narrowed to 'wordp' (aka '__uintcap_t *') in initializer list}}
   // expected-error@-5 {{const_cast from 'void * __capability' to 'wordp' (aka '__uintcap_t *') is not allowed}}
@@ -157,7 +157,7 @@ void cast_ptr() {
   test_class* __capability b = nullptr;
   DO_ALL_CASTS(test_class_ptr, b);
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-warning@-2 5 {{cast from capability type 'test_class * __capability' to non-capability, non-address type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
+  // expected-error@-2 5 {{cast from capability type 'test_class * __capability' to integer pointer type 'test_class_ptr' (aka 'test_class *') is most likely an error}}
   // expected-note@-3 5 {{use __cheri_cast to convert between pointers and capabilities}}
   // expected-error@-4 {{test_class * __capability' cannot be narrowed to 'test_class_ptr' (aka 'test_class *') in initializer list}}
   // expected-error@-5 {{static_cast from 'test_class * __capability' to 'test_class_ptr' (aka 'test_class *'), which are not related by inheritance, is not allowed}} // TODO: this should be a better error message

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -1,0 +1,49 @@
+
+// check that we get the same (or more) errors when compiling as C++ code
+// RUN: %cheri_cc1 -x c -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify
+// RUN: %cheri_cc1 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify
+
+
+int global_int;
+
+void addrof(void) {
+    // capability from taking address of global in hybrid mode is an error:
+    int* __capability intcap = &global_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'int * __capability' with an {{(expression of incompatible)|(rvalue of)}} type 'int *'}}
+    void* __capability vcap = &global_int; // expected-error-re  {{{{initializing|(cannot initialize a variable of type)}} 'void * __capability' with an {{(expression of incompatible)|(rvalue of)}} type 'int *'}}
+    // but fine for pointers
+    int* intptr = &global_int; // okay
+    void* vptr = &global_int; // okay
+}
+
+int foo(int* __capability cap_arg_int, void* __capability cap_arg_void, int* ptr_arg_int, void* ptr_arg_void) {
+  // pointer -> cap
+  int* __capability intcap = ptr_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'int * __capability' with an {{(expression of incompatible)|(lvalue of)}} type 'int *'}}
+  void* __capability vcap = ptr_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'void * __capability' with an {{(expression of incompatible)|(lvalue of)}} type 'int *'}}
+#ifdef NOTYET
+  // cap -> pointer
+  int* intptr = cap_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'int *' with an {{(expression of incompatible)|(lvalue of)}} type 'int * __capability'}}
+  void* vptr = cap_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'void *' with an {{(expression of incompatible)|(lvalue of)}} type 'int * __capability'}}
+#endif
+  // to void*
+  void* __capability vcap2 = cap_arg_int; // casting to void* should work without a cast
+  void* vptr2 = ptr_arg_int; // casting to void* should work without a cast
+
+  // cap/pointer -> __uintcap_t needs a cast
+  __uintcap_t uintcap1 = cap_arg_int;
+  __uintcap_t uintcap2 = cap_arg_void;
+  __uintcap_t uintcap3 = ptr_arg_int;
+  __uintcap_t uintcap4 = ptr_arg_void;
+// TODO: the C error message is better we should be able to produce something like that
+#ifdef __cplusplus
+  // expected-error@-6 {{cannot initialize a variable of type '__uintcap_t' with an lvalue of type 'int * __capability'}}
+  // expected-error@-6 {{cannot initialize a variable of type '__uintcap_t' with an lvalue of type 'void * __capability'}}
+  // expected-error@-6 {{cannot initialize a variable of type '__uintcap_t' with an lvalue of type 'int *'}}
+  // expected-error@-6 {{cannot initialize a variable of type '__uintcap_t' with an lvalue of type 'void *'}}
+#else
+  // expected-warning@-11 {{incompatible pointer to integer conversion initializing '__uintcap_t' with an expression of type 'int * __capability'}}
+  // expected-warning@-11 {{incompatible pointer to integer conversion initializing '__uintcap_t' with an expression of type 'void * __capability'}}
+  // expected-warning@-11 {{incompatible pointer to integer conversion initializing '__uintcap_t' with an expression of type 'int *'}}
+  // expected-warning@-11 {{incompatible pointer to integer conversion initializing '__uintcap_t' with an expression of type 'void *'}}
+#endif
+  return 0;
+}

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -76,6 +76,23 @@ int foo(int* __capability cap_arg_int, void* __capability cap_arg_void, int* ptr
   return 0;
 }
 
+void str_to_ptr() {
+  // conversion from string literal to const char* is fine:
+  const char* ptr = "foo";
+  const char* __capability cap = "foo";
+
+  // but conversion from a pointer isn't
+  const char* __capability cap2 = ptr;  // expected-error {{converting pointer type 'const char *' to capability type 'const char * __capability' without an explicit cast}}
+
+  // conversion to char* should be an error:
+  char* nonconst_ptr = "foo";
+  char* __capability nonconst_cap = "foo";
+#ifdef __cplusplus
+  // expected-warning@-3 {{conversion from string literal to 'char *' is deprecated}}
+  // expected-error@-3 {{converting pointer type 'const char [4]' to capability type 'char * __capability' without an explicit cast}}
+#endif
+
+}
 // not yet implemented
 #if 0
 void test_references(int& ptrref, int& __capability capref) {

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -79,10 +79,17 @@ int foo(int* __capability cap_arg_int, void* __capability cap_arg_void, int* ptr
   return 0;
 }
 
+void fn_taking_const_char_ptr(const char* s);
+void fn_taking_const_char_cap(const char* __capability s);
+
 void str_to_ptr(void) {
   // conversion from string literal to const char* is fine:
   const char* ptr = "foo";
   const char* __capability cap = "foo";
+
+  // check that we can also call functions with string literals:
+  fn_taking_const_char_ptr("foo");
+  fn_taking_const_char_cap("foo");
 
   // but conversion from a pointer isn't
   const char* __capability cap2 = ptr;  // expected-error {{converting pointer type 'const char *' to capability type 'const char * __capability' without an explicit cast}}

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -19,11 +19,9 @@ int foo(int* __capability cap_arg_int, void* __capability cap_arg_void, int* ptr
   // pointer -> cap
   int* __capability intcap = ptr_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'int * __capability' with an {{(expression of incompatible)|(lvalue of)}} type 'int *'}}
   void* __capability vcap = ptr_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'void * __capability' with an {{(expression of incompatible)|(lvalue of)}} type 'int *'}}
-#ifdef NOTYET
   // cap -> pointer
   int* intptr = cap_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'int *' with an {{(expression of incompatible)|(lvalue of)}} type 'int * __capability'}}
   void* vptr = cap_arg_int; // expected-error-re {{{{initializing|(cannot initialize a variable of type)}} 'void *' with an {{(expression of incompatible)|(lvalue of)}} type 'int * __capability'}}
-#endif
   // to void*
   void* __capability vcap2 = cap_arg_int; // casting to void* should work without a cast
   void* vptr2 = ptr_arg_int; // casting to void* should work without a cast

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -1,4 +1,3 @@
-
 // check that we get the same (or more) errors when compiling as C++ code
 // RUN: %cheri_cc1 -x c -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify
 // RUN: %cheri_cc1 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify

--- a/test/SemaCXX/cheri-implicit-conversion.cpp
+++ b/test/SemaCXX/cheri-implicit-conversion.cpp
@@ -44,3 +44,19 @@ int foo(int* __capability cap_arg_int, void* __capability cap_arg_void, int* ptr
 #endif
   return 0;
 }
+
+#ifdef NOTYET
+void test_references(int& ptrref, int& __capability capref) {
+  // TODO: look at callers of Sema::CompareReferenceRelationship
+  int& ptr1 = ptrref; // okay
+  int& ptr2 = capref; // expected-error {{foooof}}
+
+  int& __capability cap1 = capref; // okay
+  int& __capability cap2 = ptrref; // expected-error {{foooof}}
+
+  int i;
+
+  int& ptrref2 = i;
+  int& __capability capref2 = i; //expected-error{{dasdasds}}
+}
+#endif

--- a/test/SemaCXX/cheri-one-pointer-ctor.cpp
+++ b/test/SemaCXX/cheri-one-pointer-ctor.cpp
@@ -1,7 +1,10 @@
 // RUN: %cheri_cc1 -std=c++11 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify
 // RUN: %cheri_purecap_cc1 -std=c++11 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -std=c++11
 // previous changes broke constructors that take one pointer argument and treated them as a functional C style case (-Wcapability-to-integer-cast)
+
+#ifdef __CHERI_PURE_CAPABILITY__
 // expected-no-diagnostics
+#endif
 
 template<class T>
 class future {
@@ -19,4 +22,87 @@ future<void> test1() {
 }
 future<void> test2() {
   return future<void>(&test_func);  // this used to warn about casting a capability to future<void>
+}
+
+// Array initialization test case from libc++ memory.cpp:
+
+
+#if __cplusplus >= 201103L
+#define NULL nullptr
+#define _LIBCPP_CONSTEXPR constexpr
+#define _NOEXCEPT noexcept
+#else
+#define NULL __null
+#define _LIBCPP_CONSTEXPR
+#define _NOEXCEPT throw()
+#endif
+
+class __sp_mut {
+  void* __lx;
+public:
+  void lock() _NOEXCEPT;
+  void unlock() _NOEXCEPT;
+
+private:
+  _LIBCPP_CONSTEXPR __sp_mut(void*) _NOEXCEPT;
+  __sp_mut(const __sp_mut&);
+  __sp_mut& operator=(const __sp_mut&);
+
+  friend __sp_mut& __get_sp_mut(const void*);
+};
+
+_LIBCPP_CONSTEXPR __sp_mut::__sp_mut(void* p) _NOEXCEPT
+    : __lx(p)
+{
+}
+
+
+struct pthread_mutex;
+typedef pthread_mutex* pthread_mutex_t;
+typedef pthread_mutex_t __libcpp_mutex_t;
+#define _LIBCPP_MUTEX_INITIALIZER NULL
+
+
+#define _LIBCPP_SAFE_STATIC __attribute__((__require_constant_initialization__))
+_LIBCPP_SAFE_STATIC static const long __sp_mut_count = 4;
+_LIBCPP_SAFE_STATIC static __libcpp_mutex_t mut_back[__sp_mut_count] =
+{
+    _LIBCPP_MUTEX_INITIALIZER, _LIBCPP_MUTEX_INITIALIZER, _LIBCPP_MUTEX_INITIALIZER, _LIBCPP_MUTEX_INITIALIZER,
+};
+
+__sp_mut&
+__get_sp_mut(const void* p)
+{
+  // all these here are fine
+  __sp_mut dummy{&mut_back[ 0]};
+  __sp_mut dummy2 = {&mut_back[ 0]};
+  __sp_mut dummy3 = &mut_back[ 0];
+  static __sp_mut muts[__sp_mut_count]
+  {
+      &mut_back[ 0], &mut_back[ 1], &mut_back[ 2], &mut_back[ 3],
+  };
+  // return muts[hash<const void*>()(p) & (__sp_mut_count-1)];
+  extern unsigned index;
+  return muts[index & (__sp_mut_count-1)];
+}
+
+class ctor_with_cap_arg {
+public:
+  ctor_with_cap_arg(void* __capability);
+};
+
+void test_cap_conversion_still_fails() {
+  static ctor_with_cap_arg muts[__sp_mut_count]
+  {
+      &mut_back[ 0], &mut_back[ 1], &mut_back[ 2], &mut_back[ 3],
+  };
+  static  pthread_mutex* __capability muts2[__sp_mut_count]
+  {
+      mut_back[ 0], mut_back[ 1], mut_back[ 2], mut_back[ 3]
+  };
+#ifndef __CHERI_PURE_CAPABILITY__
+  // expected-error@-7 4 {{converting pointer type '__libcpp_mutex_t *' (aka 'pthread_mutex **') to capability type 'void * __capability' without an explicit cast; if this is intended use __cheri_cast}}
+  // expected-note@-14 4 {{passing argument to parameter here}}
+  // expected-error@-5 4 {{converting pointer type '__libcpp_mutex_t' (aka 'pthread_mutex *') to capability type 'pthread_mutex * __capability' without an explicit cast; if this is intended use __cheri_cast}}
+#endif
 }

--- a/test/SemaCXX/cheri-one-pointer-ctor.cpp
+++ b/test/SemaCXX/cheri-one-pointer-ctor.cpp
@@ -101,8 +101,8 @@ void test_cap_conversion_still_fails() {
       mut_back[ 0], mut_back[ 1], mut_back[ 2], mut_back[ 3]
   };
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-7 4 {{converting pointer type '__libcpp_mutex_t *' (aka 'pthread_mutex **') to capability type 'void * __capability' without an explicit cast; if this is intended use __cheri_cast}}
+  // expected-error@-7 4 {{converting non-capability type '__libcpp_mutex_t *' (aka 'pthread_mutex **') to capability type 'void * __capability' without an explicit cast; if this is intended use __cheri_cast}}
   // expected-note@-14 4 {{passing argument to parameter here}}
-  // expected-error@-5 4 {{converting pointer type '__libcpp_mutex_t' (aka 'pthread_mutex *') to capability type 'pthread_mutex * __capability' without an explicit cast; if this is intended use __cheri_cast}}
+  // expected-error@-5 4 {{converting non-capability type '__libcpp_mutex_t' (aka 'pthread_mutex *') to capability type 'pthread_mutex * __capability' without an explicit cast; if this is intended use __cheri_cast}}
 #endif
 }

--- a/test/SemaCXX/cheri-one-pointer-ctor.cpp
+++ b/test/SemaCXX/cheri-one-pointer-ctor.cpp
@@ -1,0 +1,22 @@
+// RUN: %cheri_cc1 -std=c++11 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -verify
+// RUN: %cheri_purecap_cc1 -std=c++11 -x c++ -o - %s -fsyntax-only -Wall -Wno-unused-variable -std=c++11
+// previous changes broke constructors that take one pointer argument and treated them as a functional C style case (-Wcapability-to-integer-cast)
+// expected-no-diagnostics
+
+template<class T>
+class future {
+public:
+  typedef T(*Func)();
+  future(Func f);
+};
+
+void test_func() {
+  return;
+}
+
+future<void> test1() {
+  return future<void>(test_func);
+}
+future<void> test2() {
+  return future<void>(&test_func);  // this used to warn about casting a capability to future<void>
+}

--- a/test/SemaCXX/cheri-pointer-cast.cpp
+++ b/test/SemaCXX/cheri-pointer-cast.cpp
@@ -1,6 +1,6 @@
-/ RUN: %clang_cc1 -triple mips64-unknown-freebsd -target-abi n64 %s -std=c++14 -verify
-/ RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi n64 %s -std=c++14 -verify
-/ RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi purecap %s -std=c++14 -verify
+// RUN: %clang_cc1 -triple mips64-unknown-freebsd -target-abi n64 %s -std=c++14 -verify
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi n64 %s -std=c++14 -verify
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi purecap %s -std=c++14 -verify
 
 #pragma clang diagnostic warning "-Wcapability-to-integer-cast"
 
@@ -78,7 +78,7 @@ T offset_set(T x, long off) {
   // expected-warning@-1 {{cast from capability type 'void * __capability' to non-capability, non-address type 'long'}}
   // expected-warning@-2 {{cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced.}} expected-note@-2 {{insert cast to intptr_t to silence this warning}}
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-4 {{cast from capability type 'void * __capability' to integer pointer type 'x *'}} expected-note@-4 {{use __cheri_cast to convert between pointers and capabilities}}
+  // expected-error@-4 {{cast from capability type 'void * __capability' to non-capability type 'x *'}} expected-note@-4 {{use __cheri_cast to convert between pointers and capabilities}}
 #endif
 }
 

--- a/test/SemaCXX/cheri-pointer-cast.cpp
+++ b/test/SemaCXX/cheri-pointer-cast.cpp
@@ -78,7 +78,7 @@ T offset_set(T x, long off) {
   // expected-warning@-1 {{cast from capability type 'void * __capability' to non-capability, non-address type 'long'}}
   // expected-warning@-2 {{cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced.}} expected-note@-2 {{insert cast to intptr_t to silence this warning}}
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-error@-4 {{cast from capability type 'void * __capability' to non-capability type 'x *'}} expected-note@-4 {{use __cheri_cast to convert between pointers and capabilities}}
+  // expected-error@-4 {{cast from capability type 'void * __capability' to non-capability type 'x *'}}
 #endif
 }
 

--- a/test/SemaCXX/cheri-pointer-cast.cpp
+++ b/test/SemaCXX/cheri-pointer-cast.cpp
@@ -78,7 +78,7 @@ T offset_set(T x, long off) {
   // expected-warning@-1 {{cast from capability type 'void * __capability' to non-capability, non-address type 'long'}}
   // expected-warning@-2 {{cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced.}} expected-note@-2 {{insert cast to intptr_t to silence this warning}}
 #ifndef __CHERI_PURE_CAPABILITY__
-  // expected-warning@-4 {{cast from capability type 'void * __capability' to non-capability, non-address type 'x *'}} expected-note@-4 {{use __cheri_cast to convert between pointers and capabilities}}
+  // expected-error@-4 {{cast from capability type 'void * __capability' to integer pointer type 'x *'}} expected-note@-4 {{use __cheri_cast to convert between pointers and capabilities}}
 #endif
 }
 

--- a/test/SemaCXX/cheri-pointer-cast.cpp
+++ b/test/SemaCXX/cheri-pointer-cast.cpp
@@ -1,6 +1,8 @@
-// RUN: %clang_cc1 -triple mips64-unknown-freebsd -target-abi n64 %s -std=c++14 -verify
-// RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi n64 %s -std=c++14 -verify
-// RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi purecap %s -std=c++14 -verify
+/ RUN: %clang_cc1 -triple mips64-unknown-freebsd -target-abi n64 %s -std=c++14 -verify
+/ RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi n64 %s -std=c++14 -verify
+/ RUN: %clang_cc1 -triple cheri-unknown-freebsd  -target-abi purecap %s -std=c++14 -verify
+
+#pragma clang diagnostic warning "-Wcapability-to-integer-cast"
 
 typedef unsigned int uint;
 typedef unsigned long ulong;

--- a/test/SemaCXX/cheri-pointer-cast.cpp
+++ b/test/SemaCXX/cheri-pointer-cast.cpp
@@ -14,15 +14,18 @@ int foo;
 #endif
 
 #define DO_CASTS(dest, value) do { \
-  unsigned long cstyle = (dest)value; \
-  unsigned long functional = dest(value); \
-  unsigned long staticCast = static_cast<dest>(value); \
-  unsigned long reinterpretCast = reinterpret_cast<dest>(value); \
+  dest cstyle = (dest)value; \
+  dest functional = dest(value); \
+  dest staticCast = static_cast<dest>(value); \
+  dest reinterpretCast = reinterpret_cast<dest>(value); \
 } while(false)
 
 int main() {
-  void* CAP x = &foo;
+  void* CAP x = (int* CAP)&foo;
   DO_CASTS(ulong, x); //expected-error-re {{static_cast from 'void *{{( __capability)?}}' to 'ulong' (aka 'unsigned long') is not allowed}}
+#ifdef __CHERI__
+  // expected-warning@-2 3 {{cast from capability type 'void * __capability' to non-capability, non-address type 'ulong' (aka 'unsigned long') is most likely an error}}
+#endif
   DO_CASTS(uint, x);
 #ifdef __CHERI__
   // expected-error@-2 3 {{cast from capability to smaller type 'uint' (aka 'unsigned int') loses information}}
@@ -34,6 +37,10 @@ int main() {
 
   void* nocap = &foo;
   DO_CASTS(ulong, nocap); //expected-error-re {{static_cast from 'void *{{( __capability)?}}' to 'ulong' (aka 'unsigned long') is not allowed}}
+#ifdef __CHERI_PURE_CAPABILITY__
+  // expected-warning@-2 3 {{cast from capability type 'void * __capability' to non-capability, non-address type 'ulong' (aka 'unsigned long') is most likely an error}}
+#endif
+
   DO_CASTS(uint, nocap);
 #ifdef __CHERI_PURE_CAPABILITY__
   // expected-error@-2 3 {{cast from capability to smaller type 'uint' (aka 'unsigned int') loses information}}

--- a/test/SemaCXX/cheri-reference-init.cpp
+++ b/test/SemaCXX/cheri-reference-init.cpp
@@ -1,0 +1,91 @@
+// RUN: %cheri_cc1 %s -fsyntax-only -Wall -Wno-unused-variable -std=c++11 -verify
+
+
+struct ref_struct {
+    int& ref;
+};
+
+struct cap_struct {
+    int& __capability ref;
+};
+
+void test_assignment(int& ptrref, int& __capability capref) {
+  int i;
+
+  int &ptr1 = ptrref; // okay
+  int &ptr2 = capref; // expected-error {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+
+  int &__capability
+  cap1 = capref; // okay
+  int &__capability
+  cap2 = ptrref; // expected-error {{converting non-capability type 'int &' to capability type 'int & __capability' without an explicit cast}}
+
+  // can only bind a non-capability ref to i:
+  int &ptrref2 = i;
+  int &__capability capref2 = i; //expected-error{{converting non-capability reference to type 'int' to capability type 'int & __capability' without an explicit cast}}
+
+  // check intializer lists:
+  ref_struct sp1 = {ptrref};
+  ref_struct sp2 = {capref}; // expected-error {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+  ref_struct sp3 = {i};
+
+  cap_struct sc1 = {ptrref}; // expected-error{{converting non-capability type 'int &' to capability type 'int & __capability' without an explicit cast}}
+  cap_struct sc2 = {capref};
+  cap_struct sc3 = {i}; // expected-error{{converting non-capability reference to type 'int' to capability type 'int & __capability' without an explicit cast}}
+}
+
+void init(int& ptrref, int& __capability capref) {
+  using PtrRef = int &;
+  using CapRef = int & __capability;
+  int i = 0;
+
+  // function cast/ctor:
+  PtrRef pc1(ptrref);
+  PtrRef pc2(capref); // expected-error{{converting capability type 'int & __capability' to non-capability type 'PtrRef' (aka 'int &') without an explicit cast}}
+  PtrRef pc3(i);
+  CapRef cc1(ptrref); // expected-error{{converting non-capability type 'int &' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+  CapRef cc2(capref);
+  CapRef cc3(i); // expected-error{{converting non-capability reference to type 'int' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+  // brace init:
+  PtrRef pi1{ptrref};
+  PtrRef pi2{capref}; // expected-error{{converting capability type 'int & __capability' to non-capability type 'PtrRef' (aka 'int &') without an explicit cast}}
+  PtrRef pi3{i};
+  CapRef ci1{ptrref}; // expected-error{{converting non-capability type 'int &' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+  CapRef ci2{capref};
+  CapRef ci3{i}; // expected-error{{converting non-capability reference to type 'int' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+  // assign init list:
+  PtrRef pai1 = {ptrref};
+  PtrRef pai2 = {capref}; // expected-error{{converting capability type 'int & __capability' to non-capability type 'PtrRef' (aka 'int &') without an explicit cast}}
+  PtrRef pai3 = {i};
+  CapRef cai1 = {ptrref}; // expected-error{{converting non-capability type 'int &' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+  CapRef cai2 = {capref};
+  CapRef cai3 = {i}; // expected-error{{converting non-capability reference to type 'int' to capability type 'CapRef' (aka 'int & __capability') without an explicit cast}}
+}
+
+struct foo2 {
+    int& __capability cap;
+    int& ptr;
+};
+
+void test_two_member_struct(int& __capability a) {
+  foo2 f{a, a}; // expected-error {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+  foo2 f2 = {a, a}; // expected-error {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+}
+
+struct struct_with_ctor_ref {
+    struct_with_ctor_ref(int &);  // expected-note {{passing argument to parameter here}}
+};
+
+struct struct_with_ctor_cap {
+    struct_with_ctor_cap(int& __capability); // expected-note 2 {{passing argument to parameter here}}
+};
+
+void test_struct_with_ctor(int& ptrref, int& __capability capref, int i) {
+  struct_with_ctor_ref r1 = ptrref;
+  struct_with_ctor_ref r2 = capref; // expected-error {{converting capability type 'int & __capability' to non-capability type 'int &' without an explicit cast}}
+  struct_with_ctor_ref r3 = i;
+
+  struct_with_ctor_cap c1 = ptrref; // expected-error{{converting non-capability type 'int &' to capability type 'int & __capability' without an explicit cast}}
+  struct_with_ctor_cap c2 = capref;
+  struct_with_ctor_cap c3 = i; // expected-error{{converting non-capability reference to type 'int' to capability type 'int & __capability' without an explicit cast}}
+}

--- a/test/SemaCXX/cheri-reference-init.cpp
+++ b/test/SemaCXX/cheri-reference-init.cpp
@@ -89,3 +89,15 @@ void test_struct_with_ctor(int& ptrref, int& __capability capref, int i) {
   struct_with_ctor_cap c2 = capref;
   struct_with_ctor_cap c3 = i; // expected-error{{converting non-capability reference to type 'int' to capability type 'int & __capability' without an explicit cast}}
 }
+
+__intcap_t get_intcap();
+
+
+void test_intcap(__intcap_t& lval, __intcap_t&& rval) {
+  __intcap_t& ref1 = get_intcap(); // expected-error {{non-const lvalue reference to type '__intcap_t' cannot bind to a temporary of type '__intcap_t'}}
+  const __intcap_t& ref2 = get_intcap();
+  __intcap_t&& ref3 = get_intcap();
+
+  __uintcap_t intcap1 = lval;
+  __uintcap_t intcap2 = rval;
+}


### PR DESCRIPTION
Only (u)intptr_t and vaddr_t (aka __memaddr_t) are acceptable cast targets

This is quite noisy when compiling cheribsd hybrid mode code so I'm not sure I should add this yet.

I also have a change for cheribsd that tags vaddr_t as __attribute__((memory_address)) and fixes a few cast warnings. There are a lot of cases where we are casting capabilities to the corresponging pointer type in the hybrid ABI and I'm not sure how best to silence those? Possibly with a `__builtin_cheri_cap_to_pointer()` builtin?