### PR TITLE
WIP: use getPointerTo(DefaultAS) everywhere in CodeGen

### DIFF
--- a/lib/CodeGen/CGAtomic.cpp
+++ b/lib/CodeGen/CGAtomic.cpp
@@ -87,7 +87,8 @@ namespace {
             VoidPtrAddr, OffsetInChars.getQuantity());
         auto Addr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
             VoidPtrAddr,
-            CGF.Builder.getIntNTy(AtomicSizeInBits)->getPointerTo(),
+            CGF.Builder.getIntNTy(AtomicSizeInBits)->getPointerTo(
+              CGF.CGM.getTargetCodeGenInfo().getDefaultAS()),
             "atomic_bitfield_base");
         BFI = OrigBFI;
         BFI.Offset = Offset;
@@ -643,8 +644,9 @@ AddDirectArgument(CodeGenFunction &CGF, CallArgList &Args,
     int64_t SizeInBits = CGF.getContext().toBits(SizeInChars);
     ValTy =
         CGF.getContext().getIntTypeForBitwidth(SizeInBits, /*Signed=*/false);
-    llvm::Type *IPtrTy = llvm::IntegerType::get(CGF.getLLVMContext(),
-                                                SizeInBits)->getPointerTo();
+    llvm::Type *IPtrTy =
+        llvm::IntegerType::get(CGF.getLLVMContext(), SizeInBits)->getPointerTo(
+          CGF.CGM.getTargetCodeGenInfo().getDefaultAS());
     Address Ptr = Address(CGF.Builder.CreateBitCast(Val, IPtrTy), Align);
     Val = CGF.EmitLoadOfScalar(Ptr, false,
                                CGF.getContext().getPointerType(ValTy),
@@ -1011,7 +1013,8 @@ RValue CodeGenFunction::EmitAtomicExpr(AtomicExpr *E) {
 
       Builder.CreateStore(
           ResVal,
-          Builder.CreateBitCast(Dest, ResVal->getType()->getPointerTo()));
+          Builder.CreateBitCast(Dest, ResVal->getType()->getPointerTo(
+            CGM.getTargetCodeGenInfo().getDefaultAS())));
     }
 
     if (RValTy->isVoidType())

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -634,7 +634,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
       return RValue::get(llvm::ConstantFP::get(getLLVMContext(),
                                                Result.Val.getFloat()));
   }
-
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
   switch (BuiltinID) {
   default: break;  // Handle intrinsics and libm functions below.
   case Builtin::BI__builtin___CFStringMakeConstantString:
@@ -1606,7 +1606,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
     CharUnits StoreSize = getContext().getTypeSizeInChars(ElTy);
     llvm::Type *ITy = llvm::IntegerType::get(getLLVMContext(),
                                              StoreSize.getQuantity() * 8);
-    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo());
+    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo(DefaultAS));
     llvm::StoreInst *Store =
       Builder.CreateAlignedStore(llvm::Constant::getNullValue(ITy), Ptr,
                                  StoreSize);
@@ -2179,7 +2179,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const FunctionDecl *FD,
     llvm::IntegerType *IntType =
       IntegerType::get(getLLVMContext(),
                        getContext().getTypeSize(E->getType()));
-    llvm::Type *IntPtrType = IntType->getPointerTo();
+    llvm::Type *IntPtrType = IntType->getPointerTo(DefaultAS);
 
     llvm::Value *Destination =
       Builder.CreateBitCast(EmitScalarExpr(E->getArg(0)), IntPtrType);
@@ -4380,6 +4380,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
                                            const CallExpr *E) {
   if (auto Hint = GetValueForARMHint(BuiltinID))
     return Hint;
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
 
   if (BuiltinID == ARM::BI__emit) {
     bool IsThumb = getTarget().getTriple().getArch() == llvm::Triple::thumb;
@@ -4545,7 +4546,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     QualType Ty = E->getType();
     llvm::Type *RealResTy = ConvertType(Ty);
     llvm::Type *PtrTy = llvm::IntegerType::get(
-        getLLVMContext(), getContext().getTypeSize(Ty))->getPointerTo();
+        getLLVMContext(), getContext().getTypeSize(Ty))->getPointerTo(DefaultAS);
     LoadAddr = Builder.CreateBitCast(LoadAddr, PtrTy);
 
     Function *F = CGM.getIntrinsic(BuiltinID == ARM::BI__builtin_arm_ldaex
@@ -4594,7 +4595,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     QualType Ty = E->getArg(0)->getType();
     llvm::Type *StoreTy = llvm::IntegerType::get(getLLVMContext(),
                                                  getContext().getTypeSize(Ty));
-    StoreAddr = Builder.CreateBitCast(StoreAddr, StoreTy->getPointerTo());
+    StoreAddr = Builder.CreateBitCast(StoreAddr, StoreTy->getPointerTo(DefaultAS));
 
     if (StoreVal->getType()->isPointerTy())
       StoreVal = Builder.CreatePtrToInt(StoreVal, Int32Ty);
@@ -4623,7 +4624,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     CharUnits LoadSize = getContext().getTypeSizeInChars(ElTy);
     llvm::Type *ITy = llvm::IntegerType::get(getLLVMContext(),
                                              LoadSize.getQuantity() * 8);
-    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo());
+    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo(DefaultAS));
     llvm::LoadInst *Load =
       Builder.CreateAlignedLoad(Ptr, LoadSize);
     Load->setVolatile(true);
@@ -4639,7 +4640,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     CharUnits StoreSize = getContext().getTypeSizeInChars(ElTy);
     llvm::Type *ITy = llvm::IntegerType::get(getLLVMContext(),
                                              StoreSize.getQuantity() * 8);
-    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo());
+    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo(DefaultAS));
     llvm::StoreInst *Store =
       Builder.CreateAlignedStore(Value, Ptr,
                                  StoreSize);
@@ -5272,6 +5273,7 @@ Value *CodeGenFunction::vectorWrapScalar16(Value *Op) {
 Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
                                                const CallExpr *E) {
   unsigned HintID = static_cast<unsigned>(-1);
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
   switch (BuiltinID) {
   default: break;
   case AArch64::BI__builtin_arm_nop:
@@ -5377,7 +5379,7 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     QualType Ty = E->getType();
     llvm::Type *RealResTy = ConvertType(Ty);
     llvm::Type *PtrTy = llvm::IntegerType::get(
-        getLLVMContext(), getContext().getTypeSize(Ty))->getPointerTo();
+        getLLVMContext(), getContext().getTypeSize(Ty))->getPointerTo(DefaultAS);
     LoadAddr = Builder.CreateBitCast(LoadAddr, PtrTy);
 
     Function *F = CGM.getIntrinsic(BuiltinID == AArch64::BI__builtin_arm_ldaex
@@ -5424,7 +5426,7 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     QualType Ty = E->getArg(0)->getType();
     llvm::Type *StoreTy = llvm::IntegerType::get(getLLVMContext(),
                                                  getContext().getTypeSize(Ty));
-    StoreAddr = Builder.CreateBitCast(StoreAddr, StoreTy->getPointerTo());
+    StoreAddr = Builder.CreateBitCast(StoreAddr, StoreTy->getPointerTo(DefaultAS));
 
     if (StoreVal->getType()->isPointerTy())
       StoreVal = Builder.CreatePtrToInt(StoreVal, Int64Ty);

--- a/lib/CodeGen/CGCXX.cpp
+++ b/lib/CodeGen/CGCXX.cpp
@@ -149,7 +149,8 @@ bool CodeGenModule::TryEmitDefinitionAsAlias(GlobalDecl AliasDecl,
 
   // Derive the type for the alias.
   llvm::Type *AliasValueType = getTypes().GetFunctionType(AliasDecl);
-  llvm::PointerType *AliasType = AliasValueType->getPointerTo();
+  const unsigned DefaultAS = getTargetCodeGenInfo().getDefaultAS();
+  llvm::PointerType *AliasType = AliasValueType->getPointerTo(DefaultAS);
 
   // Find the referent.  Some aliases might require a bitcast, in
   // which case the caller is responsible for ensuring the soundness
@@ -268,7 +269,8 @@ static CGCallee BuildAppleKextVirtualCall(CodeGenFunction &CGF,
   GD = GD.getCanonicalDecl();
   CodeGenModule &CGM = CGF.CGM;
   llvm::Value *VTable = CGM.getCXXABI().getAddrOfVTable(RD, CharUnits());
-  Ty = Ty->getPointerTo()->getPointerTo();
+  const unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+  Ty = Ty->getPointerTo(DefaultAS)->getPointerTo(DefaultAS);
   VTable = CGF.Builder.CreateBitCast(VTable, Ty);
   assert(VTable && "BuildVirtualCall = kext vtbl pointer is null");
   uint64_t VTableIndex = CGM.getItaniumVTableContext().getMethodVTableIndex(GD);

--- a/lib/CodeGen/CGCXXABI.cpp
+++ b/lib/CodeGen/CGCXXABI.cpp
@@ -86,7 +86,8 @@ CGCallee CGCXXABI::EmitLoadOfMemberFunctionPointer(
     cast<CXXRecordDecl>(MPT->getClass()->getAs<RecordType>()->getDecl());
   llvm::FunctionType *FTy = CGM.getTypes().GetFunctionType(
       CGM.getTypes().arrangeCXXMethodType(RD, FPT, /*FD=*/nullptr));
-  llvm::Constant *FnPtr = llvm::Constant::getNullValue(FTy->getPointerTo());
+  unsigned AS = CGM.getTargetCodeGenInfo().getDefaultAS();
+  llvm::Constant *FnPtr = llvm::Constant::getNullValue(FTy->getPointerTo(AS));
   return CGCallee::forDirect(FnPtr, FPT);
 }
 

--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -1092,6 +1092,7 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
 
     if (!DidCallStackSave) {
       // Save the stack.
+      // XXXAR: Should this really be address space 0?
       Address Stack = CreateTempAlloca(Int8Ty->getPointerTo(0),
           getPointerAlign(), "saved_stack");
 

--- a/lib/CodeGen/CGObjC.cpp
+++ b/lib/CodeGen/CGObjC.cpp
@@ -901,7 +901,9 @@ CodeGenFunction::generateObjCGetterBody(const ObjCImplementationDecl *classImpl,
     // types, so there's no point in trying to pick a prettier type.
     uint64_t ivarSize = getContext().toBits(strategy.getIvarSize());
     llvm::Type *bitcastType = llvm::Type::getIntNTy(getLLVMContext(), ivarSize);
-    bitcastType = bitcastType->getPointerTo(); // addrspace 0 okay
+    // XXXAR: is that addrspace 0 okay for CHERI????
+    bitcastType = bitcastType->getPointerTo(
+        CGM.getTargetCodeGenInfo().getDefaultAS()); // addrspace 0 okay
 
     // Perform an atomic load.  This does not impose ordering constraints.
     Address ivarAddr = LV.getAddress();
@@ -918,7 +920,8 @@ CodeGenFunction::generateObjCGetterBody(const ObjCImplementationDecl *classImpl,
     if (ivarSize > retTySize) {
       llvm::Type *newTy = llvm::Type::getIntNTy(getLLVMContext(), retTySize);
       ivarVal = Builder.CreateTrunc(load, newTy);
-      bitcastType = newTy->getPointerTo();
+      bitcastType = newTy->getPointerTo(
+        CGM.getTargetCodeGenInfo().getDefaultAS());
     }
     Builder.CreateStore(ivarVal,
                         Builder.CreateBitCast(ReturnValue, bitcastType));

--- a/lib/CodeGen/CGObjCMac.cpp
+++ b/lib/CodeGen/CGObjCMac.cpp
@@ -363,10 +363,12 @@ public:
     return CGM.CreateRuntimeFunction(FTy, "objc_lookUpClass");
   }
 
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+
   /// GcReadWeakFn -- LLVM objc_read_weak (id *src) function.
   llvm::Constant *getGcReadWeakFn() {
     // id objc_read_weak (id *)
-    llvm::Type *args[] = { ObjectPtrTy->getPointerTo() };
+    llvm::Type *args[] = { ObjectPtrTy->getPointerTo(DefaultAS) };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
     return CGM.CreateRuntimeFunction(FTy, "objc_read_weak");
@@ -375,7 +377,7 @@ public:
   /// GcAssignWeakFn -- LLVM objc_assign_weak function.
   llvm::Constant *getGcAssignWeakFn() {
     // id objc_assign_weak (id, id *)
-    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo() };
+    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(DefaultAS) };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
     return CGM.CreateRuntimeFunction(FTy, "objc_assign_weak");
@@ -384,7 +386,7 @@ public:
   /// GcAssignGlobalFn -- LLVM objc_assign_global function.
   llvm::Constant *getGcAssignGlobalFn() {
     // id objc_assign_global(id, id *)
-    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo() };
+    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(DefaultAS) };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
     return CGM.CreateRuntimeFunction(FTy, "objc_assign_global");
@@ -393,7 +395,7 @@ public:
   /// GcAssignThreadLocalFn -- LLVM objc_assign_threadlocal function.
   llvm::Constant *getGcAssignThreadLocalFn() {
     // id objc_assign_threadlocal(id src, id * dest)
-    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo() };
+    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(DefaultAS) };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
     return CGM.CreateRuntimeFunction(FTy, "objc_assign_threadlocal");
@@ -402,7 +404,7 @@ public:
   /// GcAssignIvarFn -- LLVM objc_assign_ivar function.
   llvm::Constant *getGcAssignIvarFn() {
     // id objc_assign_ivar(id, id *, ptrdiff_t)
-    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(),
+    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(DefaultAS),
                            CGM.PtrDiffTy };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
@@ -420,7 +422,7 @@ public:
   /// GcAssignStrongCastFn -- LLVM objc_assign_strongCast function.
   llvm::Constant *getGcAssignStrongCastFn() {
     // id objc_assign_strongCast(id, id *)
-    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo() };
+    llvm::Type *args[] = { ObjectPtrTy, ObjectPtrTy->getPointerTo(DefaultAS) };
     llvm::FunctionType *FTy =
       llvm::FunctionType::get(ObjectPtrTy, args, false);
     return CGM.CreateRuntimeFunction(FTy, "objc_assign_strongCast");
@@ -555,7 +557,8 @@ public:
   
   /// ExceptionTryEnterFn - LLVM objc_exception_try_enter function.
   llvm::Constant *getExceptionTryEnterFn() {
-    llvm::Type *params[] = { ExceptionDataTy->getPointerTo() };
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+    llvm::Type *params[] = { ExceptionDataTy->getPointerTo(DefaultAS) };
     return CGM.CreateRuntimeFunction(
       llvm::FunctionType::get(CGM.VoidTy, params, false),
       "objc_exception_try_enter");
@@ -563,7 +566,8 @@ public:
 
   /// ExceptionTryExitFn - LLVM objc_exception_try_exit function.
   llvm::Constant *getExceptionTryExitFn() {
-    llvm::Type *params[] = { ExceptionDataTy->getPointerTo() };
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+    llvm::Type *params[] = { ExceptionDataTy->getPointerTo(DefaultAS) };
     return CGM.CreateRuntimeFunction(
       llvm::FunctionType::get(CGM.VoidTy, params, false),
       "objc_exception_try_exit");
@@ -571,7 +575,8 @@ public:
 
   /// ExceptionExtractFn - LLVM objc_exception_extract function.
   llvm::Constant *getExceptionExtractFn() {
-    llvm::Type *params[] = { ExceptionDataTy->getPointerTo() };
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+    llvm::Type *params[] = { ExceptionDataTy->getPointerTo(DefaultAS) };
     return CGM.CreateRuntimeFunction(llvm::FunctionType::get(ObjectPtrTy,
                                                              params, false),
                                      "objc_exception_extract");
@@ -588,7 +593,8 @@ public:
   /// SetJmpFn - LLVM _setjmp function.
   llvm::Constant *getSetJmpFn() {
     // This is specifically the prototype for x86.
-    llvm::Type *params[] = { CGM.Int32Ty->getPointerTo() };
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+    llvm::Type *params[] = { CGM.Int32Ty->getPointerTo(DefaultAS) };
     return
       CGM.CreateRuntimeFunction(llvm::FunctionType::get(CGM.Int32Ty,
                                                         params, false),
@@ -1886,7 +1892,8 @@ llvm::Constant *CGObjCMac::getNSConstantStringClassRef() {
 
   llvm::Type *PTy = llvm::ArrayType::get(CGM.IntTy, 0);
   auto GV = CGM.CreateRuntimeVariable(PTy, str);
-  auto V = llvm::ConstantExpr::getBitCast(GV, CGM.IntTy->getPointerTo());
+  auto V = llvm::ConstantExpr::getBitCast(GV, CGM.IntTy->getPointerTo(
+      CGM.getTargetCodeGenInfo().getDefaultAS()));
   ConstantStringClassRef = V;
   return V;
 }
@@ -1902,7 +1909,8 @@ llvm::Constant *CGObjCNonFragileABIMac::getNSConstantStringClassRef() {
   auto GV = GetClassGlobal(str, NotForDefinition);
 
   // Make sure the result is of the correct type.
-  auto V = llvm::ConstantExpr::getBitCast(GV, CGM.IntTy->getPointerTo());
+  auto V = llvm::ConstantExpr::getBitCast(GV, CGM.IntTy->getPointerTo(
+      CGM.getTargetCodeGenInfo().getDefaultAS()));
 
   ConstantStringClassRef = V;
   return V;
@@ -1924,7 +1932,7 @@ CGObjCCommonMac::GenerateConstantNSString(const StringLiteral *Literal) {
   if (!NSConstantStringType) {
     NSConstantStringType =
       llvm::StructType::create({
-        CGM.Int32Ty->getPointerTo(),
+        CGM.Int32Ty->getPointerTo(CGM.getTargetCodeGenInfo().getDefaultAS()),
         CGM.Int8PtrTy,
         CGM.IntTy
       }, "struct.__builtin_NSString");
@@ -5827,7 +5835,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(CodeGen::CodeGenModul
   // ImpnfABITy - LLVM for id (*)(id, SEL, ...)
   llvm::Type *params[] = { ObjectPtrTy, SelectorPtrTy };
   ImpnfABITy = llvm::FunctionType::get(ObjectPtrTy, params, false)
-                 ->getPointerTo();
+                 ->getPointerTo(CGM.getTargetCodeGenInfo().getDefaultAS());
 
   // struct _class_t {
   //   struct _class_t *isa;
@@ -6260,7 +6268,8 @@ void CGObjCNonFragileABIMac::GenerateClass(const ObjCImplementationDecl *ID) {
                                    "_objc_empty_vtable");
     else
       ObjCEmptyVtableVar =
-        llvm::ConstantPointerNull::get(ObjCTypes.ImpnfABITy->getPointerTo());
+        llvm::ConstantPointerNull::get(ObjCTypes.ImpnfABITy->getPointerTo(
+          CGM.getTargetCodeGenInfo().getDefaultAS()));
   }
 
   // FIXME: Is this correct (that meta class size is never computed)?

--- a/lib/CodeGen/CGObjCRuntime.cpp
+++ b/lib/CodeGen/CGObjCRuntime.cpp
@@ -367,7 +367,8 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
       CGM.getTypes().arrangeObjCMessageSendSignature(method, callArgs[0].Ty);
 
     llvm::PointerType *signatureType =
-      CGM.getTypes().GetFunctionType(signature)->getPointerTo();
+      CGM.getTypes().GetFunctionType(signature)->getPointerTo(
+        CGM.getTargetCodeGenInfo().getDefaultAS());
 
     const CGFunctionInfo &signatureForCall =
       CGM.getTypes().arrangeCall(signature, callArgs);
@@ -381,6 +382,7 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
 
   // Derive the signature to call from that.
   llvm::PointerType *signatureType =
-    CGM.getTypes().GetFunctionType(argsInfo)->getPointerTo();
+    CGM.getTypes().GetFunctionType(argsInfo)->getPointerTo(
+      CGM.getTargetCodeGenInfo().getDefaultAS());
   return MessageSendInfo(argsInfo, signatureType);
 }

--- a/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -1076,6 +1076,7 @@ llvm::Type *CGOpenMPRuntime::getKmpc_MicroPointerTy() {
 llvm::Constant *
 CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
   llvm::Constant *RTLFn = nullptr;
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
   switch (static_cast<OpenMPRTLFunction>(Function)) {
   case OMPRTL__kmpc_fork_call: {
     // Build void __kmpc_fork_call(ident_t *loc, kmp_int32 argc, kmpc_micro
@@ -1100,7 +1101,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
     // kmp_int32 global_tid, void *data, size_t size, void ***cache);
     llvm::Type *TypeParams[] = {getIdentTyPointerTy(), CGM.Int32Ty,
                                 CGM.VoidPtrTy, CGM.SizeTy,
-                                CGM.VoidPtrTy->getPointerTo()->getPointerTo()};
+                                CGM.VoidPtrTy->getPointerTo(DefaultAS)->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidPtrTy, TypeParams, /*isVarArg*/ false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, "__kmpc_threadprivate_cached");
@@ -1134,16 +1135,16 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
     // typedef void *(*kmpc_ctor)(void *);
     auto KmpcCtorTy =
         llvm::FunctionType::get(CGM.VoidPtrTy, CGM.VoidPtrTy,
-                                /*isVarArg*/ false)->getPointerTo();
+                                /*isVarArg*/ false)->getPointerTo(DefaultAS);
     // typedef void *(*kmpc_cctor)(void *, void *);
     llvm::Type *KmpcCopyCtorTyArgs[] = {CGM.VoidPtrTy, CGM.VoidPtrTy};
     auto KmpcCopyCtorTy =
         llvm::FunctionType::get(CGM.VoidPtrTy, KmpcCopyCtorTyArgs,
-                                /*isVarArg*/ false)->getPointerTo();
+                                /*isVarArg*/ false)->getPointerTo(DefaultAS);
     // typedef void (*kmpc_dtor)(void *);
     auto KmpcDtorTy =
         llvm::FunctionType::get(CGM.VoidTy, CGM.VoidPtrTy, /*isVarArg*/ false)
-            ->getPointerTo();
+            ->getPointerTo(DefaultAS);
     llvm::Type *FnTyArgs[] = {getIdentTyPointerTy(), CGM.VoidPtrTy, KmpcCtorTy,
                               KmpcCopyCtorTy, KmpcDtorTy};
     auto FnTy = llvm::FunctionType::get(CGM.VoidTy, FnTyArgs,
@@ -1296,7 +1297,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
     auto *CpyFnTy =
         llvm::FunctionType::get(CGM.VoidTy, CpyTypeParams, /*isVarArg=*/false);
     llvm::Type *TypeParams[] = {getIdentTyPointerTy(), CGM.Int32Ty, CGM.SizeTy,
-                                CGM.VoidPtrTy, CpyFnTy->getPointerTo(),
+                                CGM.VoidPtrTy, CpyFnTy->getPointerTo(DefaultAS),
                                 CGM.Int32Ty};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg=*/false);
@@ -1312,7 +1313,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                                /*isVarArg=*/false);
     llvm::Type *TypeParams[] = {
         getIdentTyPointerTy(), CGM.Int32Ty, CGM.Int32Ty, CGM.SizeTy,
-        CGM.VoidPtrTy, ReduceFnTy->getPointerTo(),
+        CGM.VoidPtrTy, ReduceFnTy->getPointerTo(DefaultAS),
         llvm::PointerType::getUnqual(KmpCriticalNameTy)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.Int32Ty, TypeParams, /*isVarArg=*/false);
@@ -1329,7 +1330,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                                /*isVarArg=*/false);
     llvm::Type *TypeParams[] = {
         getIdentTyPointerTy(), CGM.Int32Ty, CGM.Int32Ty, CGM.SizeTy,
-        CGM.VoidPtrTy, ReduceFnTy->getPointerTo(),
+        CGM.VoidPtrTy, ReduceFnTy->getPointerTo(DefaultAS),
         llvm::PointerType::getUnqual(KmpCriticalNameTy)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.Int32Ty, TypeParams, /*isVarArg=*/false);
@@ -1501,8 +1502,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.IntTy,
                                 CGM.VoidPtrTy,
                                 CGM.IntTy,
-                                CGM.Int64Ty->getPointerTo(),
-                                CGM.Int64Ty->getPointerTo(),
+                                CGM.Int64Ty->getPointerTo(DefaultAS),
+                                CGM.Int64Ty->getPointerTo(DefaultAS),
                                 CGM.Int64Ty,
                                 CGM.IntTy,
                                 CGM.IntTy,
@@ -1537,7 +1538,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
     // Build void __kmpc_doacross_post(ident_t *loc, kmp_int32 gtid, kmp_int64
     // *vec);
     llvm::Type *TypeParams[] = {getIdentTyPointerTy(), CGM.Int32Ty,
-                                CGM.Int64Ty->getPointerTo()};
+                                CGM.Int64Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg=*/false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, /*Name=*/"__kmpc_doacross_post");
@@ -1547,7 +1548,7 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
     // Build void __kmpc_doacross_wait(ident_t *loc, kmp_int32 gtid, kmp_int64
     // *vec);
     llvm::Type *TypeParams[] = {getIdentTyPointerTy(), CGM.Int32Ty,
-                                CGM.Int64Ty->getPointerTo()};
+                                CGM.Int64Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg=*/false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, /*Name=*/"__kmpc_doacross_wait");
@@ -1562,8 +1563,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.Int32Ty,
                                 CGM.VoidPtrPtrTy,
                                 CGM.VoidPtrPtrTy,
-                                CGM.SizeTy->getPointerTo(),
-                                CGM.Int32Ty->getPointerTo()};
+                                CGM.SizeTy->getPointerTo(DefaultAS),
+                                CGM.Int32Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.Int32Ty, TypeParams, /*isVarArg*/ false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, "__tgt_target");
@@ -1578,8 +1579,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.Int32Ty,
                                 CGM.VoidPtrPtrTy,
                                 CGM.VoidPtrPtrTy,
-                                CGM.SizeTy->getPointerTo(),
-                                CGM.Int32Ty->getPointerTo(),
+                                CGM.SizeTy->getPointerTo(DefaultAS),
+                                CGM.Int32Ty->getPointerTo(DefaultAS),
                                 CGM.Int32Ty,
                                 CGM.Int32Ty};
     llvm::FunctionType *FnTy =
@@ -1614,8 +1615,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.Int32Ty,
                                 CGM.VoidPtrPtrTy,
                                 CGM.VoidPtrPtrTy,
-                                CGM.SizeTy->getPointerTo(),
-                                CGM.Int32Ty->getPointerTo()};
+                                CGM.SizeTy->getPointerTo(DefaultAS),
+                                CGM.Int32Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg*/ false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, "__tgt_target_data_begin");
@@ -1628,8 +1629,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.Int32Ty,
                                 CGM.VoidPtrPtrTy,
                                 CGM.VoidPtrPtrTy,
-                                CGM.SizeTy->getPointerTo(),
-                                CGM.Int32Ty->getPointerTo()};
+                                CGM.SizeTy->getPointerTo(DefaultAS),
+                                CGM.Int32Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg*/ false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, "__tgt_target_data_end");
@@ -1642,8 +1643,8 @@ CGOpenMPRuntime::createRuntimeFunction(unsigned Function) {
                                 CGM.Int32Ty,
                                 CGM.VoidPtrPtrTy,
                                 CGM.VoidPtrPtrTy,
-                                CGM.SizeTy->getPointerTo(),
-                                CGM.Int32Ty->getPointerTo()};
+                                CGM.SizeTy->getPointerTo(DefaultAS),
+                                CGM.Int32Ty->getPointerTo(DefaultAS)};
     llvm::FunctionType *FnTy =
         llvm::FunctionType::get(CGM.VoidTy, TypeParams, /*isVarArg*/ false);
     RTLFn = CGM.CreateRuntimeFunction(FnTy, "__tgt_target_data_update");
@@ -1866,21 +1867,22 @@ llvm::Function *CGOpenMPRuntime::emitThreadPrivateVarDefinition(
       return nullptr;
 
     llvm::Type *CopyCtorTyArgs[] = {CGM.VoidPtrTy, CGM.VoidPtrTy};
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
     auto CopyCtorTy =
         llvm::FunctionType::get(CGM.VoidPtrTy, CopyCtorTyArgs,
-                                /*isVarArg=*/false)->getPointerTo();
+                                /*isVarArg=*/false)->getPointerTo(DefaultAS);
     // Copying constructor for the threadprivate variable.
     // Must be NULL - reserved by runtime, but currently it requires that this
     // parameter is always NULL. Otherwise it fires assertion.
     CopyCtor = llvm::Constant::getNullValue(CopyCtorTy);
     if (Ctor == nullptr) {
       auto CtorTy = llvm::FunctionType::get(CGM.VoidPtrTy, CGM.VoidPtrTy,
-                                            /*isVarArg=*/false)->getPointerTo();
+                                            /*isVarArg=*/false)->getPointerTo(DefaultAS);
       Ctor = llvm::Constant::getNullValue(CtorTy);
     }
     if (Dtor == nullptr) {
       auto DtorTy = llvm::FunctionType::get(CGM.VoidTy, CGM.VoidPtrTy,
-                                            /*isVarArg=*/false)->getPointerTo();
+                                            /*isVarArg=*/false)->getPointerTo(DefaultAS);
       Dtor = llvm::Constant::getNullValue(DtorTy);
     }
     if (!CGF) {
@@ -2291,8 +2293,9 @@ void CGOpenMPRuntime::emitSingleRegion(CodeGenFunction &CGF,
     }
     // Build function that copies private values from single region to all other
     // threads in the corresponding parallel region.
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
     auto *CpyFn = emitCopyprivateCopyFunction(
-        CGM, CGF.ConvertTypeForMem(CopyprivateArrayTy)->getPointerTo(),
+        CGM, CGF.ConvertTypeForMem(CopyprivateArrayTy)->getPointerTo(DefaultAS),
         CopyprivateVars, SrcExprs, DstExprs, AssignmentOps);
     auto *BufSize = CGF.getTypeSize(CopyprivateArrayTy);
     Address CL =
@@ -3773,7 +3776,8 @@ CGOpenMPRuntime::emitTaskInit(CodeGenFunction &CGF, SourceLocation Loc,
   QualType KmpTaskTWithPrivatesPtrQTy =
       C.getPointerType(KmpTaskTWithPrivatesQTy);
   auto *KmpTaskTWithPrivatesTy = CGF.ConvertType(KmpTaskTWithPrivatesQTy);
-  auto *KmpTaskTWithPrivatesPtrTy = KmpTaskTWithPrivatesTy->getPointerTo();
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+  auto *KmpTaskTWithPrivatesPtrTy = KmpTaskTWithPrivatesTy->getPointerTo(DefaultAS);
   auto *KmpTaskTWithPrivatesTySize = CGF.getTypeSize(KmpTaskTWithPrivatesQTy);
   QualType SharedsPtrTy = C.getPointerType(SharedsTy);
 
@@ -4465,8 +4469,9 @@ void CGOpenMPRuntime::emitReduction(CodeGenFunction &CGF, SourceLocation Loc,
   }
 
   // 2. Emit reduce_func().
+  unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
   auto *ReductionFn = emitReductionFunction(
-      CGM, CGF.ConvertTypeForMem(ReductionArrayTy)->getPointerTo(), Privates,
+      CGM, CGF.ConvertTypeForMem(ReductionArrayTy)->getPointerTo(DefaultAS), Privates,
       LHSExprs, RHSExprs, ReductionOps);
 
   // 3. Create static kmp_critical_name lock = { 0 };
@@ -5984,9 +5989,10 @@ static void emitOffloadingArraysArgument(
   } else {
     BasePointersArrayArg = llvm::ConstantPointerNull::get(CGM.VoidPtrPtrTy);
     PointersArrayArg = llvm::ConstantPointerNull::get(CGM.VoidPtrPtrTy);
-    SizesArrayArg = llvm::ConstantPointerNull::get(CGM.SizeTy->getPointerTo());
+    unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
+    SizesArrayArg = llvm::ConstantPointerNull::get(CGM.SizeTy->getPointerTo(DefaultAS));
     MapTypesArrayArg =
-        llvm::ConstantPointerNull::get(CGM.Int32Ty->getPointerTo());
+        llvm::ConstantPointerNull::get(CGM.Int32Ty->getPointerTo(DefaultAS));
   }
 }
 

--- a/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/lib/CodeGen/CGStmtOpenMP.cpp
@@ -979,10 +979,11 @@ static LValue loadToBegin(CodeGenFunction &CGF, QualType BaseTy, QualType ElTy,
     }
     BaseTy = BaseTy->getPointeeType();
   }
+  unsigned DefaultAS = CGF.CGM.getTargetCodeGenInfo().getDefaultAS();
   return CGF.MakeAddrLValue(
       Address(
           CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-              BaseLV.getPointer(), CGF.ConvertTypeForMem(ElTy)->getPointerTo()),
+              BaseLV.getPointer(), CGF.ConvertTypeForMem(ElTy)->getPointerTo(DefaultAS)),
           BaseLV.getAlignment()),
       BaseLV.getType(), BaseLV.getAlignmentSource());
 }

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -1963,8 +1963,8 @@ CodeGenModule::GetOrCreateLLVMFunction(StringRef MangledName,
     // (If function is requested for a definition, we always need to create a new
     // function, not just return a bitcast.)
     if (!IsForDefinition) {
-      unsigned DefaultAS = getTargetCodeGenInfo().getDefaultAS();
-      return llvm::ConstantExpr::getBitCast(Entry, Ty->getPointerTo(DefaultAS)); // XXXAR: is this needed?
+      // AS0 OKAY: LLVM functions are always in AS0
+      return llvm::ConstantExpr::getBitCast(Entry, Ty->getPointerTo(0));
     }
   }
 
@@ -2005,9 +2005,9 @@ CodeGenModule::GetOrCreateLLVMFunction(StringRef MangledName,
       Entry->removeDeadConstantUsers();
     }
 
-    unsigned DefaultAS = getTargetCodeGenInfo().getDefaultAS(); // XXXAR: is this needed?
+    // AS0 OKAY: LLVM functions are always in AS0
     llvm::Constant *BC = llvm::ConstantExpr::getBitCast(
-        F, Entry->getType()->getElementType()->getPointerTo(DefaultAS));
+        F, Entry->getType()->getElementType()->getPointerTo(0));
 
     addGlobalValReplacement(Entry, BC);
   }

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -1962,8 +1962,10 @@ CodeGenModule::GetOrCreateLLVMFunction(StringRef MangledName,
     // Make sure the result is of the correct type.
     // (If function is requested for a definition, we always need to create a new
     // function, not just return a bitcast.)
-    if (!IsForDefinition)
-      return llvm::ConstantExpr::getBitCast(Entry, Ty->getPointerTo());
+    if (!IsForDefinition) {
+      unsigned DefaultAS = getTargetCodeGenInfo().getDefaultAS();
+      return llvm::ConstantExpr::getBitCast(Entry, Ty->getPointerTo(DefaultAS)); // XXXAR: is this needed?
+    }
   }
 
   // This function doesn't have a complete type (for example, the return
@@ -2003,8 +2005,10 @@ CodeGenModule::GetOrCreateLLVMFunction(StringRef MangledName,
       Entry->removeDeadConstantUsers();
     }
 
+    unsigned DefaultAS = getTargetCodeGenInfo().getDefaultAS(); // XXXAR: is this needed?
     llvm::Constant *BC = llvm::ConstantExpr::getBitCast(
-        F, Entry->getType()->getElementType()->getPointerTo());
+        F, Entry->getType()->getElementType()->getPointerTo(DefaultAS));
+
     addGlobalValReplacement(Entry, BC);
   }
 

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -1155,7 +1155,7 @@ void X86_32TargetCodeGenInfo::addReturnRegisterOutputs(
 
   // Coerce the integer by bitcasting the return slot pointer.
   ReturnSlot.setAddress(CGF.Builder.CreateBitCast(ReturnSlot.getAddress(),
-                                                  CoerceTy->getPointerTo()));
+                                                  CoerceTy->getPointerTo(getDefaultAS())));
   ResultRegDests.push_back(ReturnSlot);
 
   rewriteInputConstraintReferences(NumOutputs, 1, AsmString);

--- a/test/CodeGen/cheri-noproto-fn-impl.c
+++ b/test/CodeGen/cheri-noproto-fn-impl.c
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple cheri-unknown-freebsd -target-abi purecap -emit-llvm -o - %s | FileCheck %s
+
+static void
+crt_init_globals()
+{
+  void *gdc = __builtin_cheri_global_data_get();
+  void *pcc = __builtin_cheri_program_counter_get();
+}
+
+void
+__start(void)
+{
+  // CHECK: %0 = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+  // CHECK: %1 = call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* %0, i64 ptrtoint (void ()* @crt_init_globals to i64))
+  // CHECK: %2 = bitcast i8 addrspace(200)* %1 to void (...) addrspace(200)*
+  // CHECK: %callee.knr.cast = bitcast void (...) addrspace(200)* %2 to void () addrspace(200)*
+  // CHECK: call void %callee.knr.cast()
+  crt_init_globals();
+}


### PR DESCRIPTION
I am not sure all of these are required, but quite a few look like they are needed.

I am also not sure that lib/CodeGen/ItaniumCXXABI.cpp is doing the right casting, sometimes it is using ptrdiff_t and sometimes intptr_t