### PR TITLE
Implement pointers to members for CHERI

### DIFF
--- a/lib/AST/ItaniumCXXABI.cpp
+++ b/lib/AST/ItaniumCXXABI.cpp
@@ -107,8 +107,14 @@ public:
     TargetInfo::IntType PtrDiff = Target.getPtrDiffType(0);
     uint64_t Width = Target.getTypeWidth(PtrDiff);
     unsigned Align = Target.getTypeAlign(PtrDiff);
-    if (MPT->isMemberFunctionPointer())
-      Width = 2 * Width;
+    if (MPT->isMemberFunctionPointer()) {
+      if (Context.getTargetInfo().areAllPointersCapabilities()) {
+        Width = 2 * Context.getTargetInfo().getMemoryCapabilityWidth();
+        Align = Context.getTargetInfo().getMemoryCapabilityAlign();
+      } else {
+        Width = 2 * Width;
+      }
+    }
     return std::make_pair(Width, Align);
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -394,6 +394,10 @@ bool Type::isMemoryCapabilityType(const ASTContext &Context) const {
       return true;
     if (Kind == BuiltinType::ObjCId)
       return Context.getTargetInfo().areAllPointersCapabilities();
+  } else if  (const MemberPointerType *MPT = getAs<MemberPointerType>()) {
+    // XXXAR: Currently member function pointers contain capabities, but
+    // pointers to member data don't
+    return Context.getTargetInfo().areAllPointersCapabilities() && MPT->isMemberFunctionPointer();
   }
   return false;
 }

--- a/lib/CodeGen/CGBuiltin.cpp
+++ b/lib/CodeGen/CGBuiltin.cpp
@@ -5566,7 +5566,8 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
                                      CharUnits::fromQuantity(16));
   }
   case NEON::BI__builtin_neon_vstrq_p128: {
-    llvm::Type *Int128PTy = llvm::Type::getIntNPtrTy(getLLVMContext(), 128);
+    llvm::Type *Int128PTy = llvm::Type::getIntNPtrTy(getLLVMContext(), 128,
+                                                     DefaultAS);
     Value *Ptr = Builder.CreateBitCast(Ops[0], Int128PTy);
     return Builder.CreateDefaultAlignedStore(EmitScalarExpr(E->getArg(1)), Ptr);
   }

--- a/lib/CodeGen/CGCXXABI.cpp
+++ b/lib/CodeGen/CGCXXABI.cpp
@@ -136,7 +136,7 @@ CGCXXABI::EmitNullMemberPointer(const MemberPointerType *MPT) {
   return GetBogusMemberPointer(QualType(MPT, 0));
 }
 
-llvm::Constant *CGCXXABI::EmitMemberFunctionPointer(const CXXMethodDecl *MD) {
+llvm::Constant *CGCXXABI::EmitMemberFunctionPointerGlobal(const CXXMethodDecl *MD) {
   return GetBogusMemberPointer(CGM.getContext().getMemberPointerType(
       MD->getType(), MD->getParent()->getTypeForDecl()));
 }
@@ -146,7 +146,8 @@ llvm::Constant *CGCXXABI::EmitMemberDataPointer(const MemberPointerType *MPT,
   return GetBogusMemberPointer(QualType(MPT, 0));
 }
 
-llvm::Constant *CGCXXABI::EmitMemberPointer(const APValue &MP, QualType MPT) {
+llvm::Constant *CGCXXABI::EmitMemberPointer(const APValue &MP, QualType MPT,
+                                            CodeGenFunction* CGF) {
   return GetBogusMemberPointer(MPT);
 }
 

--- a/lib/CodeGen/CGCXXABI.h
+++ b/lib/CodeGen/CGCXXABI.h
@@ -190,14 +190,24 @@ public:
   virtual llvm::Constant *EmitNullMemberPointer(const MemberPointerType *MPT);
 
   /// Create a member pointer for the given method.
-  virtual llvm::Constant *EmitMemberFunctionPointer(const CXXMethodDecl *MD);
+  virtual llvm::Constant *
+  EmitMemberFunctionPointerGlobal(const CXXMethodDecl *MD);
+
+  /// XXX: CHERI:
+  /// This needs to be different from EmitMemberFunctionPointerGlobal
+  /// because there we can rely on capsizefix the set the correct permissions
+  /// but inside a function we need to derrive from PCC
+  virtual llvm::Value *
+  EmitNonGlobalMemberFunctionPointer(CodeGenFunction& CGF,
+                                     const CXXMethodDecl *MD) = 0;
 
   /// Create a member pointer for the given field.
   virtual llvm::Constant *EmitMemberDataPointer(const MemberPointerType *MPT,
                                                 CharUnits offset);
 
   /// Create a member pointer for the given member pointer constant.
-  virtual llvm::Constant *EmitMemberPointer(const APValue &MP, QualType MPT);
+  virtual llvm::Constant *EmitMemberPointer(const APValue &MP, QualType MPT,
+                                            CodeGenFunction *CGF);
 
   /// Emit a comparison between two member pointers.  Returns an i1.
   virtual llvm::Value *

--- a/lib/CodeGen/CGClass.cpp
+++ b/lib/CodeGen/CGClass.cpp
@@ -751,7 +751,8 @@ void CodeGenFunction::EmitAsanPrologueOrEpilogue(bool Prologue) {
     uint64_t Offset;
   };
 
-  unsigned PtrSize = CGM.getDataLayout().getPointerSizeInBits();
+  unsigned PtrSize = CGM.getDataLayout().getPointerSizeInBits(
+      CGM.getTargetCodeGenInfo().getDefaultAS());
   const ASTRecordLayout &Info = Context.getASTRecordLayout(ClassDecl);
 
   // Populate sizes and offsets of fields.

--- a/lib/CodeGen/CGCoroutine.cpp
+++ b/lib/CodeGen/CGCoroutine.cpp
@@ -73,7 +73,7 @@ void CodeGenFunction::EmitCoreturnStmt(CoreturnStmt const &S) {
 }
 
 void CodeGenFunction::EmitCoroutineBody(const CoroutineBodyStmt &S) {
-  auto *NullPtr = llvm::ConstantPointerNull::get(Builder.getInt8PtrTy());
+  auto *NullPtr = llvm::ConstantPointerNull::get(CGM.Int8PtrTy);
   auto &TI = CGM.getContext().getTargetInfo();
   unsigned NewAlign = TI.getNewAlign() / TI.getCharWidth();
 

--- a/lib/CodeGen/CGDebugInfo.cpp
+++ b/lib/CodeGen/CGDebugInfo.cpp
@@ -1535,7 +1535,7 @@ CGDebugInfo::CollectTemplateParams(const TemplateParameterList *TPList,
       // Member function pointers have special support for building them, though
       // this is currently unsupported in LLVM CodeGen.
       else if ((MD = dyn_cast<CXXMethodDecl>(D)) && MD->isInstance())
-        V = CGM.getCXXABI().EmitMemberFunctionPointer(MD);
+        V = CGM.getCXXABI().EmitMemberFunctionPointerGlobal(MD);
       else if (const auto *FD = dyn_cast<FunctionDecl>(D))
         V = CGM.GetAddrOfFunction(FD);
       // Member data pointers have special handling too to compute the fixed

--- a/lib/CodeGen/CGExprCXX.cpp
+++ b/lib/CodeGen/CGExprCXX.cpp
@@ -2164,3 +2164,20 @@ void CodeGenFunction::EmitLambdaExpr(const LambdaExpr *E, AggValueSlot Slot) {
     }
   }
 }
+
+llvm::Value *
+CodeGenFunction::EmitCXXMemberPointerAddressOf(const UnaryOperator *uo) {
+  // Member pointer constants always have a very particular form.
+  const MemberPointerType *type = cast<MemberPointerType>(uo->getType());
+  const ValueDecl *decl = cast<DeclRefExpr>(uo->getSubExpr())->getDecl();
+
+  // A member function pointer.
+  // We have to be
+  if (const CXXMethodDecl *method = dyn_cast<CXXMethodDecl>(decl))
+    return CGM.getCXXABI().EmitNonGlobalMemberFunctionPointer(*this, method);
+
+  // Otherwise, a member data pointer.
+  uint64_t fieldOffset = getContext().getFieldOffset(decl);
+  CharUnits chars = getContext().toCharUnitsFromBits((int64_t) fieldOffset);
+  return CGM.getCXXABI().EmitMemberDataPointer(type, chars);
+}

--- a/lib/CodeGen/CGExprConstant.cpp
+++ b/lib/CodeGen/CGExprConstant.cpp
@@ -1479,7 +1479,7 @@ llvm::Constant *CodeGenModule::EmitConstantValue(const APValue &Value,
     return llvm::ConstantArray::get(AType, Elts);
   }
   case APValue::MemberPointer:
-    return getCXXABI().EmitMemberPointer(Value, DestType);
+    return getCXXABI().EmitMemberPointer(Value, DestType, CGF);
   }
   llvm_unreachable("Unknown APValue kind");
 }
@@ -1515,14 +1515,15 @@ CodeGenModule::GetAddrOfConstantCompoundLiteral(const CompoundLiteralExpr *E) {
 }
 
 llvm::Constant *
-CodeGenModule::getMemberPointerConstant(const UnaryOperator *uo) {
+CodeGenModule::getMemberPointerConstant(const UnaryOperator *uo,
+                                        CodeGenFunction *CGF) {
   // Member pointer constants always have a very particular form.
   const MemberPointerType *type = cast<MemberPointerType>(uo->getType());
   const ValueDecl *decl = cast<DeclRefExpr>(uo->getSubExpr())->getDecl();
 
   // A member function pointer.
   if (const CXXMethodDecl *method = dyn_cast<CXXMethodDecl>(decl))
-    return getCXXABI().EmitMemberFunctionPointer(method);
+    return getCXXABI().EmitMemberFunctionPointerGlobal(method);
 
   // Otherwise, a member data pointer.
   uint64_t fieldOffset = getContext().getFieldOffset(decl);

--- a/lib/CodeGen/CGExprScalar.cpp
+++ b/lib/CodeGen/CGExprScalar.cpp
@@ -439,9 +439,9 @@ public:
 
 
   Value *VisitUnaryAddrOf(const UnaryOperator *E) {
-    if (isa<MemberPointerType>(E->getType())) // never sugared
-      return CGF.CGM.getMemberPointerConstant(E);
-
+    if (isa<MemberPointerType>(E->getType())) {// never sugared
+      return CGF.EmitCXXMemberPointerAddressOf(E);
+    }
     llvm::Value *Addr = EmitLValue(E->getSubExpr()).getPointer();
     llvm::Type *AddrTy = Addr->getType();
     auto &TI = CGF.getContext().getTargetInfo();

--- a/lib/CodeGen/CGGPUBuiltin.cpp
+++ b/lib/CodeGen/CGGPUBuiltin.cpp
@@ -21,9 +21,10 @@
 using namespace clang;
 using namespace CodeGen;
 
-static llvm::Function *GetVprintfDeclaration(llvm::Module &M) {
-  llvm::Type *ArgTypes[] = {llvm::Type::getInt8PtrTy(M.getContext()),
-                            llvm::Type::getInt8PtrTy(M.getContext())};
+static llvm::Function *GetVprintfDeclaration(CodeGenModule& CGM) {
+  llvm::Module &M = CGM.getModule();
+  // XXXAR: is this the correct signature?
+  llvm::Type *ArgTypes[] = {CGM.Int8PtrTy, CGM.Int8PtrTy};
   llvm::FunctionType *VprintfFuncType = llvm::FunctionType::get(
       llvm::Type::getInt32Ty(M.getContext()), ArgTypes, false);
 
@@ -74,7 +75,6 @@ CodeGenFunction::EmitNVPTXDevicePrintfCallExpr(const CallExpr *E,
   assert(E->getNumArgs() >= 1); // printf always has at least one arg.
 
   const llvm::DataLayout &DL = CGM.getDataLayout();
-  llvm::LLVMContext &Ctx = CGM.getLLVMContext();
 
   CallArgList Args;
   EmitCallArgs(Args,
@@ -93,7 +93,7 @@ CodeGenFunction::EmitNVPTXDevicePrintfCallExpr(const CallExpr *E,
   llvm::Value *BufferPtr;
   if (Args.size() <= 1) {
     // If there are no args, pass a null pointer to vprintf.
-    BufferPtr = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(Ctx));
+    BufferPtr = llvm::ConstantPointerNull::get(CGM.Int8PtrTy);
   } else {
     llvm::SmallVector<llvm::Type *, 8> ArgTypes;
     for (unsigned I = 1, NumArgs = Args.size(); I < NumArgs; ++I)
@@ -112,11 +112,11 @@ CodeGenFunction::EmitNVPTXDevicePrintfCallExpr(const CallExpr *E,
       llvm::Value *Arg = Args[I].RV.getScalarVal();
       Builder.CreateAlignedStore(Arg, P, DL.getPrefTypeAlignment(Arg->getType()));
     }
-    BufferPtr = Builder.CreatePointerCast(Alloca, llvm::Type::getInt8PtrTy(Ctx));
+    BufferPtr = Builder.CreatePointerCast(Alloca, CGM.Int8PtrTy);
   }
 
   // Invoke vprintf and return.
-  llvm::Function* VprintfFunc = GetVprintfDeclaration(CGM.getModule());
+  llvm::Function* VprintfFunc = GetVprintfDeclaration(CGM);
   return RValue::get(
       Builder.CreateCall(VprintfFunc, {Args[0].RV.getScalarVal(), BufferPtr}));
 }

--- a/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -468,7 +468,7 @@ void CGRecordLowering::accumulateVPtrs() {
             getPointerTo(AS)->getPointerTo(AS)));
   if (Layout.hasOwnVBPtr())
     Members.push_back(MemberInfo(Layout.getVBPtrOffset(), MemberInfo::VBPtr,
-        llvm::Type::getInt32PtrTy(Types.getLLVMContext())));
+        llvm::Type::getInt32PtrTy(Types.getLLVMContext(), AS)));
 }
 
 void CGRecordLowering::accumulateVBases() {

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -1664,7 +1664,7 @@ CodeGenFunction::EmitNullInitialization(Address DestPtr, QualType Ty) {
                                NullConstant, Twine());
     CharUnits NullAlign = DestPtr.getAlignment();
     NullVariable->setAlignment(NullAlign.getQuantity());
-    Address SrcPtr(Builder.CreateBitCast(NullVariable, Builder.getInt8PtrTy()),
+    Address SrcPtr(Builder.CreatePointerBitCastOrAddrSpaceCast(NullVariable, CGM.Int8PtrTy),
                    NullAlign);
 
     if (vla) return emitNonZeroVLAInit(*this, Ty, DestPtr, SrcPtr, SizeVal);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3172,6 +3172,7 @@ public:
                                           llvm::Value *memberPtr,
                                           const MemberPointerType *memberPtrType,
                                           AlignmentSource *AlignSource = nullptr);
+  llvm::Value* EmitCXXMemberPointerAddressOf(const UnaryOperator *uo);
   RValue EmitCXXMemberPointerCallExpr(const CXXMemberCallExpr *E,
                                       ReturnValueSlot ReturnValue);
 

--- a/lib/CodeGen/CodeGenModule.h
+++ b/lib/CodeGen/CodeGenModule.h
@@ -941,7 +941,8 @@ public:
   // Make sure that this type is translated.
   void UpdateCompletedType(const TagDecl *TD);
 
-  llvm::Constant *getMemberPointerConstant(const UnaryOperator *e);
+  llvm::Constant *getMemberPointerConstant(const UnaryOperator *e,
+                                           CodeGenFunction *CGF);
 
   /// Try to emit the initializer for the given declaration as a constant;
   /// returns 0 if the expression cannot be emitted as a constant.

--- a/lib/CodeGen/CodeGenPGO.cpp
+++ b/lib/CodeGen/CodeGenPGO.cpp
@@ -747,7 +747,7 @@ void CodeGenPGO::emitCounterIncrement(CGBuilderTy &Builder, const Stmt *S,
     return;
 
   unsigned Counter = (*RegionCounterMap)[S];
-  auto *I8PtrTy = llvm::Type::getInt8PtrTy(CGM.getLLVMContext());
+  auto *I8PtrTy = CGM.Int8PtrTy;
 
   llvm::Value *Args[] = {llvm::ConstantExpr::getBitCast(FuncNameVar, I8PtrTy),
                          Builder.getInt64(FunctionHash),
@@ -781,7 +781,7 @@ void CodeGenPGO::valueProfile(CGBuilderTy &Builder, uint32_t ValueKind,
     auto BuilderInsertPoint = Builder.saveIP();
     Builder.SetInsertPoint(ValueSite);
     llvm::Value *Args[5] = {
-        llvm::ConstantExpr::getBitCast(FuncNameVar, Builder.getInt8PtrTy()),
+        llvm::ConstantExpr::getBitCast(FuncNameVar, CGM.Int8PtrTy),
         Builder.getInt64(FunctionHash),
         Builder.CreatePtrToInt(ValuePtr, Builder.getInt64Ty()),
         Builder.getInt32(ValueKind),

--- a/lib/CodeGen/CoverageMappingGen.cpp
+++ b/lib/CodeGen/CoverageMappingGen.cpp
@@ -1027,7 +1027,7 @@ void CoverageMappingModuleGen::addFunctionMappingRecord(
       FunctionRecordTy, makeArrayRef(FunctionRecordVals)));
   if (!IsUsed)
     FunctionNames.push_back(
-        llvm::ConstantExpr::getBitCast(NamePtr, llvm::Type::getInt8PtrTy(Ctx)));
+        llvm::ConstantExpr::getBitCast(NamePtr, CGM.Int8PtrTy));
   CoverageMappings.push_back(CoverageMapping);
 
   if (CGM.getCodeGenOpts().DumpCoverageMapping) {
@@ -1128,8 +1128,7 @@ void CoverageMappingModuleGen::emit() {
   CGM.addUsedGlobal(CovData);
   // Create the deferred function records array
   if (!FunctionNames.empty()) {
-    auto NamesArrTy = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx),
-                                           FunctionNames.size());
+    auto NamesArrTy = llvm::ArrayType::get(CGM.Int8PtrTy, FunctionNames.size());
     auto NamesArrVal = llvm::ConstantArray::get(NamesArrTy, FunctionNames);
     // This variable will *NOT* be emitted to the object file. It is used
     // to pass the list of names referenced to codegen.

--- a/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/lib/CodeGen/ItaniumCXXABI.cpp
@@ -587,7 +587,7 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
   CGF.EmitBlock(FnVirtual);
 
   // Cast the adjusted this to a pointer to vtable pointer and load.
-  llvm::Type *VTableTy = Builder.getInt8PtrTy(DefaultAS);
+  llvm::Type *VTableTy = CGM.Int8PtrTy;
   CharUnits VTablePtrAlign =
     CGF.CGM.getDynamicOffsetAlignment(ThisAddr.getAlignment(), RD,
                                       CGF.getPointerAlign());

--- a/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1064,7 +1064,7 @@ void ItaniumCXXABI::emitVirtualObjectDelete(CodeGenFunction &CGF,
     auto *ClassDecl =
         cast<CXXRecordDecl>(ElementType->getAs<RecordType>()->getDecl());
     llvm::Value *VTable =
-        CGF.GetVTablePtr(Ptr, CGF.IntPtrTy->getPointerTo(DefaultAS), ClassDecl);
+        CGF.GetVTablePtr(Ptr, CGF.PtrDiffTy->getPointerTo(DefaultAS), ClassDecl);
 
     // Track back to entry -2 and pull out the offset there.
     llvm::Value *OffsetPtr = CGF.Builder.CreateConstInBoundsGEP1_64(
@@ -1334,7 +1334,6 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF,
   auto *ClassDecl =
       cast<CXXRecordDecl>(SrcRecordTy->getAs<RecordType>()->getDecl());
   // Get the vtable pointer.
-  // XXXAR: this looks wrong, shouldn't it be intptr_t?
   unsigned DefaultAS = CGM.getTargetCodeGenInfo().getDefaultAS();
   llvm::Value *VTable = CGF.GetVTablePtr(ThisAddr, PtrDiffLTy->getPointerTo(DefaultAS),
       ClassDecl);

--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -6760,6 +6760,12 @@ llvm::Type* MipsABIInfo::HandleAggregates(QualType Ty, uint64_t TySize) const {
 
   // Unions/vectors are passed in integer registers.
   if (!RT || !RT->isStructureOrClassType()) {
+    const TargetInfo &Target = getContext().getTargetInfo();
+    if (Target.areAllPointersCapabilities()) {
+      if (Ty->isMemberFunctionPointerType()) {
+        return llvm::StructType::get(CGM.VoidPtrTy, CGM.PtrDiffTy, nullptr);
+      }
+    }
     CoerceToIntArgs(TySize, ArgList);
     return llvm::StructType::get(getVMContext(), ArgList);
   }

--- a/test/CodeGen/cheri-vla.c
+++ b/test/CodeGen/cheri-vla.c
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 %s "-target-abi" "purecap" -triple cheri-unknown-freebsd -o - -S -O2 | FileCheck %s -check-prefix ASM
+// RUN: %clang_cc1 %s "-target-abi" "purecap" -emit-llvm -triple cheri-unknown-freebsd -o - -O2 | FileCheck %s
+
+extern void test(const char*);
+
+void foo(void) {
+  for (long i = 1; i < 32; i++) {
+    char vla[i];
+    vla[i - 1] = '\0';
+    test(vla);
+  }
+  // CHECK-LABEL: for.body:
+  // CHECK: %i.05 = phi i64 [ 1, %entry ], [ %inc, %for.body ]
+  // CHECK: %0 = call i8* @llvm.stacksave()
+  // CHECK: %vla = alloca i8, i64 %i.05, align 1
+  // CHECK: %sub = add nsw i64 %i.05, -1
+  // CHECK: %arrayidx = getelementptr inbounds i8, i8 addrspace(200)* %vla, i64 %sub
+  // CHECK: store i8 0, i8 addrspace(200)* %arrayidx, align 1, !tbaa !1
+  // CHECK: call void @test(i8 addrspace(200)* nonnull %vla) #1
+  // CHECK: call void @llvm.stackrestore(i8* %0)
+  // CHECK: %inc = add nuw nsw i64 %i.05, 1
+  // CHECK: %exitcond = icmp eq i64 %inc, 32
+  // CHECK: br i1 %exitcond, label %for.cond.cleanup, label %for.body
+
+  // ASM: move     [[SAVEREG:\$[0-9]+]], $sp
+  // ASM: daddiu  $1, $17, 31
+  // ASM: and     $1, $1, $18
+  // ASM: dsubu   $1, $sp, $1
+  // ASM: move     $sp, $1
+  // ASM: csetoffset      $c1, $c11, $1
+  // ASM: csetbounds      $c3, $c1, $17
+  // ASM: daddiu  $1, $17, -1
+  // ASM: cgetpccsetoffset        $c12, $16
+  // ASM: cjalr   $c12, $c17
+  // ASM: csb     $zero, $1, 0($c3)
+  // ASM: daddiu  $17, $17, 1
+  // ASM: bne     $17, $19, .LBB0_1
+  // ASM: move     $sp, [[SAVEREG]]
+}

--- a/test/CodeGenCXX/arm64.cpp
+++ b/test/CodeGenCXX/arm64.cpp
@@ -103,13 +103,13 @@ namespace test3 {
   // CHECK:       [[ADJUST_AND_IS_VIRTUAL:%.*]] = extractvalue { i64, i64 } [[MEMPTR]], 1
   // CHECK:       [[ADJUST:%.*]] = ashr i64 [[ADJUST_AND_IS_VIRTUAL]], 1
   // CHECK:       [[T0:%.*]] = bitcast [[A]]* [[TEMP]] to i8*
-  // CHECK:       [[T1:%.*]] = getelementptr inbounds i8, i8* [[T0]], i64 [[ADJUST]]
-  // CHECK:       [[ADJUSTED:%.*]] = bitcast i8* [[T1]] to [[A]]*
+  // CHECK:       [[VTABLE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[T0]], i64 [[ADJUST]]
+  // CHECK:       [[ADJUSTED:%.*]] = bitcast i8* [[VTABLE_ADDR]] to [[A]]*
   // CHECK:       [[MEMBER:%.*]] = extractvalue { i64, i64 } [[MEMPTR]], 0
   // CHECK:       [[T0:%.*]] = and i64 [[ADJUST_AND_IS_VIRTUAL]], 1
   // CHECK:       [[IS_VIRTUAL:%.*]] = icmp ne i64 [[T0]], 0
   // CHECK:       br i1 [[IS_VIRTUAL]],
-  // CHECK:       [[T0:%.*]] = bitcast [[A]]* [[ADJUSTED]] to i8**
+  // CHECK:       [[T0:%.*]] = bitcast i8* [[VTABLE_ADDR]] to i8**
   // CHECK:       [[VPTR:%.*]] = load i8*, i8** [[T0]], align 8
   // CHECK:       [[TRUNC:%.*]] = trunc i64 [[MEMBER]] to i32
   // CHECK:       [[ZEXT:%.*]] = zext i32 [[TRUNC]] to i64

--- a/test/CodeGenCXX/cheri-member-pointer-init.cpp
+++ b/test/CodeGenCXX/cheri-member-pointer-init.cpp
@@ -1,0 +1,70 @@
+// RUN: %clang -target cheri-unknown-freebsd -mabi=purecap -S -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang -target cheri-unknown-freebsd -mabi=purecap -c %s -o %t.obj
+// RUN: llvm-objdump -C -r %t.obj | FileCheck -check-prefix RELOCS-OBJ %s
+
+class A {
+public:
+  int nonvirt() { return 1; }
+  int nonvirt2() { return 2; }
+  virtual int virt() { return 3; }
+  virtual int virt2() { return 4; }
+};
+int global_fn() { return 5; }
+
+typedef int (A::* MemberPtr)();
+
+MemberPtr global_nonvirt_ptr = &A::nonvirt;
+MemberPtr global_virt_ptr = &A::virt;
+int (*global_fn_ptr)() = &global_fn;
+
+// CHECK: @global_nonvirt_ptr = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A7nonvirtEv to i8*) to i8 addrspace(200)*), i64 0 }, align 8
+// CHECK: @global_virt_ptr = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* null, i64 1 }, align 8
+// CHECK: @global_fn_ptr = addrspace(200) global i32 () addrspace(200)* addrspacecast (i32 ()* @_Z9global_fnv to i32 () addrspace(200)*), align 32
+
+int call_nonvirt(A* a) {
+  return (a->*global_nonvirt_ptr)();
+}
+
+int call_virt(A* a) {
+  return (a->*global_nonvirt_ptr)();
+}
+
+int call_local_nonvirt(A* a) {
+  MemberPtr local_nonvirt = &A::nonvirt2;
+  return (a->*local_nonvirt)();
+}
+
+int call_local_virt(A* a) {
+  MemberPtr local_virt = &A::virt2;
+  return (a->*local_virt)();
+}
+
+int call_local_fn_ptr(A* a) {
+int (*local_fn_ptr)() = &global_fn;
+  return local_fn_ptr();
+}
+
+int main() {
+  A a;
+  global_fn_ptr();
+  call_virt(&a);
+  call_nonvirt(&a);
+  call_virt(&a);
+}
+
+// RELOCS-OBJ: RELOCATION RECORDS FOR [.rela__cap_relocs]:
+// RELOCS-OBJ: 0000000000000000 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE .data
+// RELOCS-OBJ: 0000000000000008 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE _ZN1A7nonvirtEv
+// RELOCS-OBJ: 0000000000000028 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE .data
+// RELOCS-OBJ: 0000000000000030 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE _Z9global_fnv
+// RELOCS-OBJ: 0000000000000050 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE .data.rel.ro._ZTV1A
+// RELOCS-OBJ: 0000000000000058 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE _ZN1A4virtEv
+// RELOCS-OBJ: 0000000000000078 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE .data.rel.ro._ZTV1A
+// RELOCS-OBJ: 0000000000000080 R_MIPS_64/R_MIPS_NONE/R_MIPS_NONE _ZN1A5virt2Ev
+
+// RELOCS-OBJ: CAPABILITY RELOCATION RECORDS:
+// RELOCS-OBJ: 0x0000000000000000      Base:  (0x0000000000000000)     Offset: 0000000000000000        Length: 0000000000000000        Permissions: 00000000
+// RELOCS-OBJ: 0x0000000000000000      Base:  (0x0000000000000000)     Offset: 0000000000000000        Length: 0000000000000000        Permissions: 00000000
+// RELOCS-OBJ: 0x0000000000000000      Base:  (0x0000000000000000)     Offset: 0000000000000000        Length: 0000000000000000        Permissions: 00000000
+// RELOCS-OBJ: 0x0000000000000000      Base:  (0x0000000000000000)     Offset: 0000000000000000        Length: 0000000000000000        Permissions: 00000000
+

--- a/test/CodeGenCXX/cheri-pointer-to-member.cpp
+++ b/test/CodeGenCXX/cheri-pointer-to-member.cpp
@@ -54,11 +54,30 @@ int main() {
 
   AMemberFuncPtr null_func_ptr = nullptr;
   // CHECK:   store { i8 addrspace(200)*, i64 } zeroinitializer, { i8 addrspace(200)*, i64 } addrspace(200)* %null_func_ptr, align 8
+
   AMemberFuncPtr func_ptr = &A::foo;
-  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A3fooEv to i8*) to i8 addrspace(200)*), i64 0 }, { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr, align 8
+  // This IR is pretty horrible, maybe we can create something nicer
+  // CHECK: [[PCC:%.*]] = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+  // CHECK: [[NONVIRT_PTR:%.*]] = call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* [[PCC]], i64 ptrtoint (i32 (%class.A addrspace(200)*)* @_ZN1A3fooEv to i64))
+  // CHECK: [[TMP:%.*]] = getelementptr inbounds { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp, i32 0, i32 0
+  // CHECK: store i8 addrspace(200)* [[NONVIRT_PTR]], i8 addrspace(200)* addrspace(200)* [[TMP]], align 32
+  // CHECK: [[TMP:%.*]] = getelementptr inbounds { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp, i32 0, i32 1
+  // CHECK: store i64 0, i64 addrspace(200)* [[TMP]], align 32
+  // CHECK: [[TMP:%.*]] = load { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp, align 32
+  // CHECK: store { i8 addrspace(200)*, i64 } [[TMP]], { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr, align 8
+
   AMemberFuncPtr func_ptr_2 = &A::bar;
-  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A3barEv to i8*) to i8 addrspace(200)*), i64 0 }, { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr_2, align 8
-  AMemberFuncPtr virtual_func_ptr = &A::foo_virtual;
+  // CHECK: [[PCC:%.*]] = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+  // CHECK: [[NONVIRT_PTR:%.*]] = call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* [[PCC]], i64 ptrtoint (i32 (%class.A addrspace(200)*)* @_ZN1A3barEv to i64))
+  // CHECK: [[TMP:%.*]] = getelementptr inbounds { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp1, i32 0, i32 0
+  // CHECK: store i8 addrspace(200)* [[NONVIRT_PTR]], i8 addrspace(200)* addrspace(200)* [[TMP]], align 32
+  // CHECK: [[TMP:%.*]] = getelementptr inbounds { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp1, i32 0, i32 1
+  // CHECK: store i64 0, i64 addrspace(200)* [[TMP]], align 32
+  // CHECK: [[TMP:%.*]] = load { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %memptr_tmp1, align 32
+  // CHECK: store { i8 addrspace(200)*, i64 } [[TMP]], { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr_2, align 8
+  
+
+AMemberFuncPtr virtual_func_ptr = &A::foo_virtual;
   // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* null, i64 1 }, { i8 addrspace(200)*, i64 } addrspace(200)* %virtual_func_ptr, align 8
    AMemberFuncPtr virtual_func_ptr_2 = &A::bar_virtual;
   // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* inttoptr (i64 32 to i8 addrspace(200)*), i64 1 }, { i8 addrspace(200)*, i64 } addrspace(200)* %virtual_func_ptr_2, align 8

--- a/test/CodeGenCXX/cheri-pointer-to-member.cpp
+++ b/test/CodeGenCXX/cheri-pointer-to-member.cpp
@@ -186,21 +186,21 @@ int func_ptr_dereference(A* a, AMemberFuncPtr ptr) {
   // CHECK: %3 = load { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %ptr.addr, align 8
   // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %3, 1
   // CHECK: %memptr.adj.shifted = ashr i64 %memptr.adj, 1
-  // CHECK: %4 = bitcast %class.A addrspace(200)* %2 to i8 addrspace(200)*
-  // CHECK: %5 = getelementptr inbounds i8, i8 addrspace(200)* %4, i64 %memptr.adj.shifted
-  // CHECK: %this.adjusted = bitcast i8 addrspace(200)* %5 to %class.A addrspace(200)*
+  // CHECK: %this.not.adjusted = bitcast %class.A addrspace(200)* %2 to i8 addrspace(200)*
+  // CHECK: %memptr.vtable.addr = getelementptr inbounds i8, i8 addrspace(200)* %this.not.adjusted, i64 %memptr.adj.shifted
+  // CHECK: %this.adjusted = bitcast i8 addrspace(200)* %memptr.vtable.addr to %class.A addrspace(200)*
   // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %3, 0
-  // CHECK: %6 = and i64 %memptr.adj, 1
-  // CHECK: %memptr.isvirtual = icmp ne i64 %6, 0
+  // CHECK: %4 = and i64 %memptr.adj, 1
+  // CHECK: %memptr.isvirtual = icmp ne i64 %4, 0
   // CHECK: br i1 %memptr.isvirtual, label %memptr.virtual, label %memptr.nonvirtual
 
   // CHECK: memptr.virtual:                                   ; preds = %entry
-  // CHECK: %7 = bitcast %class.A addrspace(200)* %this.adjusted to i8 addrspace(200)* addrspace(200)*
-  // CHECK: %vtable = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* %7, align 32
-  // CHECK: %memptr.vtable-offset = ptrtoint i8 addrspace(200)* %memptr.ptr to i64
-  // CHECK: %8 = getelementptr i8, i8 addrspace(200)* %vtable, i64 %memptr.vtable-offset
-  // CHECK: %9 = bitcast i8 addrspace(200)* %8 to i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)*
-  // CHECK: %memptr.virtualfn = load i32 (%class.A addrspace(200)*) addrspace(200)*, i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)* %9, align 32
+  // CHECK: %5 = bitcast i8 addrspace(200)* %memptr.vtable.addr to i8 addrspace(200)* addrspace(200)*
+  // CHECK: %vtable = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* %5, align 32
+  // CHECK: %memptr.vtable.offset = ptrtoint i8 addrspace(200)* %memptr.ptr to i64
+  // CHECK: %6 = getelementptr i8, i8 addrspace(200)* %vtable, i64 %memptr.vtable.offset
+  // CHECK: %7 = bitcast i8 addrspace(200)* %6 to i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)*
+  // CHECK: %memptr.virtualfn = load i32 (%class.A addrspace(200)*) addrspace(200)*, i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)* %7, align 32
   // CHECK: br label %memptr.end
 
   // CHECK: memptr.nonvirtual:                                ; preds = %entry
@@ -208,8 +208,8 @@ int func_ptr_dereference(A* a, AMemberFuncPtr ptr) {
   // CHECK: br label %memptr.end
 
   // CHECK: memptr.end:                                       ; preds = %memptr.nonvirtual, %memptr.virtual
-  // CHECK: %10 = phi i32 (%class.A addrspace(200)*) addrspace(200)* [ %memptr.virtualfn, %memptr.virtual ], [ %memptr.nonvirtualfn, %memptr.nonvirtual ]
-  // CHECK: %call = call i32 %10(%class.A addrspace(200)* %this.adjusted)
+  // CHECK: %8 = phi i32 (%class.A addrspace(200)*) addrspace(200)* [ %memptr.virtualfn, %memptr.virtual ], [ %memptr.nonvirtualfn, %memptr.nonvirtual ]
+  // CHECK: %call = call i32 %8(%class.A addrspace(200)* %this.adjusted)
   // CHECK: ret i32 %call
 }
 

--- a/test/CodeGenCXX/cheri-pointer-to-member.cpp
+++ b/test/CodeGenCXX/cheri-pointer-to-member.cpp
@@ -1,23 +1,102 @@
-// RUN: %clang %s -mabi=purecap -cheri-linker -fno-rtti -std=c++11 -target cheri-unknown-freebsd -o - -emit-llvm -S | FileCheck %s
-// RUN: %clang %s -mabi=purecap -cheri-linker -fno-rtti -std=c++11 -target cheri-unknown-freebsd -o - -emit-llvm -S -O2 | FileCheck %s -check-prefix CHECK-OPT
-// RUN: %clang %s -mabi=purecap -cheri-linker -fno-rtti -std=c++11 -target cheri-unknown-freebsd -o - -emit-llvm -S -O3 | FileCheck %s -check-prefix CHECK-OPT
-// XFAIL: *
+// RUN: %clang %s -mabi=purecap -fno-rtti -std=c++11 -target cheri-unknown-freebsd -o - -emit-llvm -S | FileCheck %s
 
-// FIXME what should member pointer layout be on CHERI?
-// CHECK-NOT: %data_ptr = alloca i64, align 8
-// CHECK-NOT: %func_ptr = alloca { i64, i64 }, align 8
-// CHECK-NOT: %virtual_func_ptr = alloca { i64, i64 }, align 8
 class A {
 public:
   int x = 3;
+  int y = 4;
   int foo() { return 1; }
   virtual int foo_virtual() { return 2; }
+  int bar() { return 1; }
+  virtual int bar_virtual() { return 2; }
 };
 
+// compare IR with simulated function pointers:
+struct mem_fn_ptr {
+  void* ptr;
+  long offset;
+};
+void func(void) {}
+mem_fn_ptr virt = { (void*)32, 1 };
+mem_fn_ptr nonvirt = { (void*)&func, 1 };
+// CHECK: @virt = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* inttoptr (i64 32 to i8 addrspace(200)*), i64 1 }, align 32
+// CHECK: @nonvirt = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (void ()* @_Z4funcv to i8*) to i8 addrspace(200)*), i64 1 }, align 32
+
+// now the real thing
+// FIXME: why is alignment only 8 here....
+
+typedef int (A::* AMemberFuncPtr)();
+
+AMemberFuncPtr global_null_func_ptr = nullptr;
+int A::* global_data_ptr = &A::y;
+AMemberFuncPtr global_nonvirt_func_ptr = &A::bar;
+AMemberFuncPtr global_virt_func_ptr = &A::bar_virtual;
+// FIXME: align should be 32...
+// CHECK: @global_null_func_ptr = addrspace(200) global { i8 addrspace(200)*, i64 } zeroinitializer, align
+// CHECK: @global_data_ptr = addrspace(200) global i64 36, align 8
+// CHECK: @global_nonvirt_func_ptr = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A3barEv to i8*) to i8 addrspace(200)*), i64 0 }, align
+// CHECK: @global_virt_func_ptr = addrspace(200) global { i8 addrspace(200)*, i64 } { i8 addrspace(200)* inttoptr (i64 32 to i8 addrspace(200)*), i64 1 }, align
+
+
 int main() {
+  // CHECK: %data_ptr = alloca i64, align 8
+  // CHECK-NOT: %func_ptr = alloca { i64, i64 }, align 8
+  // CHECK-NOT: %virtual_func_ptr = alloca { i64, i64 }, align 8
   A a;
+  // FIXME: alignment is wrong
+  int A::* null_data_ptr = nullptr;
+  // CHECK: store i64 -1, i64 addrspace(200)* %null_data_ptr, align 8
   int A::* data_ptr = &A::x;
-  int (A::* func_ptr)()  = &A::foo;
-  int (A::* virtual_func_ptr)() = &A::foo_virtual;
-  return a.*data_ptr + (a.*func_ptr)() + (a.*virtual_func_ptr)();
+  // CHECK: store i64 32, i64 addrspace(200)* %data_ptr, align 8
+  int A::* data_ptr_2 = &A::y;
+  // CHECK: store i64 36, i64 addrspace(200)* %data_ptr_2, align 8
+
+  AMemberFuncPtr null_func_ptr = nullptr;
+  // CHECK:   store { i8 addrspace(200)*, i64 } zeroinitializer, { i8 addrspace(200)*, i64 } addrspace(200)* %null_func_ptr, align 8
+  AMemberFuncPtr func_ptr = &A::foo;
+  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A3fooEv to i8*) to i8 addrspace(200)*), i64 0 }, { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr, align 8
+  AMemberFuncPtr func_ptr_2 = &A::bar;
+  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* addrspacecast (i8* bitcast (i32 (%class.A addrspace(200)*)* @_ZN1A3barEv to i8*) to i8 addrspace(200)*), i64 0 }, { i8 addrspace(200)*, i64 } addrspace(200)* %func_ptr_2, align 8
+  AMemberFuncPtr virtual_func_ptr = &A::foo_virtual;
+  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* null, i64 1 }, { i8 addrspace(200)*, i64 } addrspace(200)* %virtual_func_ptr, align 8
+   AMemberFuncPtr virtual_func_ptr_2 = &A::bar_virtual;
+  // CHECK: store { i8 addrspace(200)*, i64 } { i8 addrspace(200)* inttoptr (i64 32 to i8 addrspace(200)*), i64 1 }, { i8 addrspace(200)*, i64 } addrspace(200)* %virtual_func_ptr_2, align 8
+
+  bool dataptr_is_null = data_ptr == nullptr;
+  // CHECK: %0 = load i64, i64 addrspace(200)* %data_ptr, align 8
+  // CHECK-NEXT: %1 = icmp eq i64 %0, -1
+
+#if 0
+  bool funcptr_is_null = !func_ptr;
+  bool virtual_func_ptr_is_null = !virtual_func_ptr;
+
+  bool datacmp = data_ptr == data_ptr_2;
+  bool funccmp = func_ptr == func_ptr_2;
+  bool vfunccmp = virtual_func_ptr == virtual_func_ptr_2;
+  bool vfunc_func_cmp = virtual_func_ptr == func_ptr;
+#endif
+
+  // return a.*data_ptr + (a.*func_ptr)() + (a.*virtual_func_ptr)();
+  // return null_func_ptr == nullptr;
+  return a.*data_ptr;
+}
+
+
+// taken from temporaries.cpp
+namespace PR7556 {
+  struct A { ~A(); };
+  struct B { int i; ~B(); };
+  struct C { int C::*pm; ~C(); };
+  // xCHECK-LABEL: define void @_ZN6PR75563fooEv()
+  void foo() {
+    // xCHECK: call void @_ZN6PR75561AD1Ev
+    A();
+    // xCHECK: call void @llvm.memset.p200i8.i64
+    // xCHECK: call void @_ZN6PR75561BD1Ev
+    B();
+    // xCHECK-NOT: llvm.memcpy.p200i8.p0i8.i64
+    // xCHECK: call void @llvm.memcpy.p200i8.p200i8.i64
+    // xCHECK: call void @_ZN6PR75561CD1Ev
+    C();
+    // xCHECK-NEXT: ret void
+  }
 }

--- a/test/CodeGenCXX/cheri-pointer-to-member.cpp
+++ b/test/CodeGenCXX/cheri-pointer-to-member.cpp
@@ -116,28 +116,24 @@ int data_ptr_dereferece(A* a, int A::* ptr) {
 // TODO: this could be simplified to test the tag bit of the address instead
 // of checking the low bit of the adjustment
 
-bool func_ptr_is_nonnull() {
-  // FIXME: member pointers are not being passed correctly as arguments (probably because ismemcaptype returns false?)
-  AMemberFuncPtr ptr = &A::bar;
+bool func_ptr_is_nonnull(AMemberFuncPtr ptr) {
   return static_cast<bool>(ptr);
-  // CHECK: define zeroext i1 @_Z19func_ptr_is_nonnullv() #0 {
-  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %0, 0
+  // CHECK: zeroext i1 @_Z19func_ptr_is_nonnullM1AFivE(i8 addrspace(200)* inreg %ptr.coerce0, i64 inreg %ptr.coerce1)
+  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %2, 0
   // CHECK: %memptr.tobool = icmp ne i8 addrspace(200)* %memptr.ptr, null
-  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %0, 1
+  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %2, 1
   // CHECK: %memptr.virtualbit = and i64 %memptr.adj, 1
   // CHECK: %memptr.isvirtual = icmp ne i64 %memptr.virtualbit, 0
   // CHECK: %memptr.isnonnull = or i1 %memptr.tobool, %memptr.isvirtual
   // CHECK: ret i1 %memptr.isnonnull
 }
 
-bool func_ptr_is_null() {
-  // FIXME: member pointers are not being passed correctly as arguments (probably because ismemcaptype returns false?)
-  AMemberFuncPtr ptr = &A::foo_virtual;
+bool func_ptr_is_null(AMemberFuncPtr ptr) {
   return !ptr;
-  // CHECK: define zeroext i1 @_Z16func_ptr_is_nullv() #0 {
-  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %0, 0
+  // CHECK: define zeroext i1 @_Z16func_ptr_is_nullM1AFivE(i8 addrspace(200)* inreg %ptr.coerce0, i64 inreg %ptr.coerce1)
+  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %2, 0
   // CHECK: %memptr.tobool = icmp ne i8 addrspace(200)* %memptr.ptr, null
-  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %0, 1
+  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %2, 1
   // CHECK: %memptr.virtualbit = and i64 %memptr.adj, 1
   // CHECK: %memptr.isvirtual = icmp ne i64 %memptr.virtualbit, 0
   // CHECK: %memptr.isnonnull = or i1 %memptr.tobool, %memptr.isvirtual
@@ -145,72 +141,66 @@ bool func_ptr_is_null() {
   // CHECK: ret i1 %lnot
 }
 
-bool func_ptr_equal() {
-  // FIXME: member pointers are not being passed correctly as arguments (probably because ismemcaptype returns false?)
-  AMemberFuncPtr ptr1 = &A::foo_virtual;
-  AMemberFuncPtr ptr2 = &A::bar;
+bool func_ptr_equal(AMemberFuncPtr ptr1, AMemberFuncPtr ptr2) {
   return ptr1 == ptr2;
-  // CHECK: define zeroext i1 @_Z14func_ptr_equalv() #0 {
-  // CHECK: %lhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %0, 0
-  // CHECK: %rhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %1, 0
+  // CHECK: define zeroext i1 @_Z14func_ptr_equalM1AFivES1_(i8 addrspace(200)* inreg %ptr1.coerce0, i64 inreg %ptr1.coerce1, i8 addrspace(200)* inreg %ptr2.coerce0, i64 inreg %ptr2.coerce1)
+  // CHECK: %lhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %4, 0
+  // CHECK: %rhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %5, 0
   // CHECK: %cmp.ptr = icmp eq i8 addrspace(200)* %lhs.memptr.ptr, %rhs.memptr.ptr
   // CHECK: %cmp.ptr.null = icmp eq i8 addrspace(200)* %lhs.memptr.ptr, null
-  // CHECK: %lhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %0, 1
-  // CHECK: %rhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %1, 1
+  // CHECK: %lhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %4, 1
+  // CHECK: %rhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %5, 1
   // CHECK: %cmp.adj = icmp eq i64 %lhs.memptr.adj, %rhs.memptr.adj
   // CHECK: %or.adj = or i64 %lhs.memptr.adj, %rhs.memptr.adj
-  // CHECK: %2 = and i64 %or.adj, 1
-  // CHECK: %cmp.or.adj = icmp eq i64 %2, 0
-  // CHECK: %3 = and i1 %cmp.ptr.null, %cmp.or.adj
-  // CHECK: %4 = or i1 %3, %cmp.adj
-  // CHECK: %memptr.eq = and i1 %cmp.ptr, %4
+  // CHECK: %6 = and i64 %or.adj, 1
+  // CHECK: %cmp.or.adj = icmp eq i64 %6, 0
+  // CHECK: %7 = and i1 %cmp.ptr.null, %cmp.or.adj
+  // CHECK: %8 = or i1 %7, %cmp.adj
+  // CHECK: %memptr.eq = and i1 %cmp.ptr, %8
   // CHECK: ret i1 %memptr.eq
 }
 
-bool func_ptr_not_equal() {
-  // FIXME: member pointers are not being passed correctly as arguments (probably because ismemcaptype returns false?)
-  AMemberFuncPtr ptr1 = &A::foo_virtual;
-  AMemberFuncPtr ptr2 = &A::bar;
+bool func_ptr_not_equal(AMemberFuncPtr ptr1, AMemberFuncPtr ptr2) {
   return ptr1 != ptr2;
-  // CHECK: define zeroext i1 @_Z18func_ptr_not_equalv()
+  // CHECK: zeroext i1 @_Z18func_ptr_not_equalM1AFivES1_(i8 addrspace(200)* inreg %ptr1.coerce0, i64 inreg %ptr1.coerce1, i8 addrspace(200)* inreg %ptr2.coerce0, i64 inreg %ptr2.coerce1)
+  // CHECK: %lhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %4, 0
+  // CHECK: %rhs.memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %5, 0
   // CHECK: %cmp.ptr = icmp ne i8 addrspace(200)* %lhs.memptr.ptr, %rhs.memptr.ptr
   // CHECK: %cmp.ptr.null = icmp ne i8 addrspace(200)* %lhs.memptr.ptr, null
-  // CHECK: %lhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %0, 1
-  // CHECK: %rhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %1, 1
+  // CHECK: %lhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %4, 1
+  // CHECK: %rhs.memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %5, 1
   // CHECK: %cmp.adj = icmp ne i64 %lhs.memptr.adj, %rhs.memptr.adj
   // CHECK: %or.adj = or i64 %lhs.memptr.adj, %rhs.memptr.adj
-  // CHECK: %2 = and i64 %or.adj, 1
-  // CHECK: %cmp.or.adj = icmp ne i64 %2, 0
-  // CHECK: %3 = or i1 %cmp.ptr.null, %cmp.or.adj
-  // CHECK: %4 = and i1 %3, %cmp.adj
-  // CHECK: %memptr.ne = or i1 %cmp.ptr, %4
+  // CHECK: %6 = and i64 %or.adj, 1
+  // CHECK: %cmp.or.adj = icmp ne i64 %6, 0
+  // CHECK: %7 = or i1 %cmp.ptr.null, %cmp.or.adj
+  // CHECK: %8 = and i1 %7, %cmp.adj
+  // CHECK: %memptr.ne = or i1 %cmp.ptr, %8
   // CHECK: ret i1 %memptr.ne
 }
 
-int func_ptr_dereference(A* a) {
-  // FIXME: member pointers are not being passed correctly as arguments (probably because ismemcaptype returns false?)
-  AMemberFuncPtr ptr = &A::foo_virtual;
+int func_ptr_dereference(A* a, AMemberFuncPtr ptr) {
   return (a->*ptr)();
-  // CHECK: define i32 @_Z20func_ptr_dereferenceP1A(%class.A addrspace(200)* %a)
-  // CHECK: %0 = load %class.A addrspace(200)*, %class.A addrspace(200)* addrspace(200)* %a.addr, align 32
-  // CHECK: %1 = load { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %ptr, align 8
-  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %1, 1
+  // CHECK: define i32 @_Z20func_ptr_dereferenceP1AMS_FivE(%class.A addrspace(200)* %a, i8 addrspace(200)* inreg %ptr.coerce0, i64 inreg %ptr.coerce1)
+  // CHECK: %2 = load %class.A addrspace(200)*, %class.A addrspace(200)* addrspace(200)* %a.addr, align 32
+  // CHECK: %3 = load { i8 addrspace(200)*, i64 }, { i8 addrspace(200)*, i64 } addrspace(200)* %ptr.addr, align 8
+  // CHECK: %memptr.adj = extractvalue { i8 addrspace(200)*, i64 } %3, 1
   // CHECK: %memptr.adj.shifted = ashr i64 %memptr.adj, 1
-  // CHECK: %2 = bitcast %class.A addrspace(200)* %0 to i8 addrspace(200)*
-  // CHECK: %3 = getelementptr inbounds i8, i8 addrspace(200)* %2, i64 %memptr.adj.shifted
-  // CHECK: %this.adjusted = bitcast i8 addrspace(200)* %3 to %class.A addrspace(200)*
-  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %1, 0
-  // CHECK: %4 = and i64 %memptr.adj, 1
-  // CHECK: %memptr.isvirtual = icmp ne i64 %4, 0
+  // CHECK: %4 = bitcast %class.A addrspace(200)* %2 to i8 addrspace(200)*
+  // CHECK: %5 = getelementptr inbounds i8, i8 addrspace(200)* %4, i64 %memptr.adj.shifted
+  // CHECK: %this.adjusted = bitcast i8 addrspace(200)* %5 to %class.A addrspace(200)*
+  // CHECK: %memptr.ptr = extractvalue { i8 addrspace(200)*, i64 } %3, 0
+  // CHECK: %6 = and i64 %memptr.adj, 1
+  // CHECK: %memptr.isvirtual = icmp ne i64 %6, 0
   // CHECK: br i1 %memptr.isvirtual, label %memptr.virtual, label %memptr.nonvirtual
 
   // CHECK: memptr.virtual:                                   ; preds = %entry
-  // CHECK: %5 = bitcast %class.A addrspace(200)* %this.adjusted to i8 addrspace(200)* addrspace(200)*
-  // CHECK: %vtable = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* %5, align 32
+  // CHECK: %7 = bitcast %class.A addrspace(200)* %this.adjusted to i8 addrspace(200)* addrspace(200)*
+  // CHECK: %vtable = load i8 addrspace(200)*, i8 addrspace(200)* addrspace(200)* %7, align 32
   // CHECK: %memptr.vtable-offset = ptrtoint i8 addrspace(200)* %memptr.ptr to i64
-  // CHECK: %6 = getelementptr i8, i8 addrspace(200)* %vtable, i64 %memptr.vtable-offset
-  // CHECK: %7 = bitcast i8 addrspace(200)* %6 to i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)*
-  // CHECK: %memptr.virtualfn = load i32 (%class.A addrspace(200)*) addrspace(200)*, i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)* %7, align 32
+  // CHECK: %8 = getelementptr i8, i8 addrspace(200)* %vtable, i64 %memptr.vtable-offset
+  // CHECK: %9 = bitcast i8 addrspace(200)* %8 to i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)*
+  // CHECK: %memptr.virtualfn = load i32 (%class.A addrspace(200)*) addrspace(200)*, i32 (%class.A addrspace(200)*) addrspace(200)* addrspace(200)* %9, align 32
   // CHECK: br label %memptr.end
 
   // CHECK: memptr.nonvirtual:                                ; preds = %entry
@@ -218,8 +208,8 @@ int func_ptr_dereference(A* a) {
   // CHECK: br label %memptr.end
 
   // CHECK: memptr.end:                                       ; preds = %memptr.nonvirtual, %memptr.virtual
-  // CHECK: %8 = phi i32 (%class.A addrspace(200)*) addrspace(200)* [ %memptr.virtualfn, %memptr.virtual ], [ %memptr.nonvirtualfn, %memptr.nonvirtual ]
-  // CHECK: %call = call i32 %8(%class.A addrspace(200)* %this.adjusted)
+  // CHECK: %10 = phi i32 (%class.A addrspace(200)*) addrspace(200)* [ %memptr.virtualfn, %memptr.virtual ], [ %memptr.nonvirtualfn, %memptr.nonvirtual ]
+  // CHECK: %call = call i32 %10(%class.A addrspace(200)* %this.adjusted)
   // CHECK: ret i32 %call
 }
 

--- a/test/CodeGenCXX/cheri-rvalue-cast.cpp
+++ b/test/CodeGenCXX/cheri-rvalue-cast.cpp
@@ -26,14 +26,21 @@ namespace PR20227 {
 
 
 // CHECK: define internal void @__cxx_global_var_init() #0 {
-// CHECK:   %0 = call i32 @__cxa_atexit(void (i8 addrspace(200)*) addrspace(200)* addrspacecast (void (i8 addrspace(200)*)* bitcast (void (%"struct.PR20227::A" addrspace(200)*)* @_ZN7PR202271AD1Ev to void (i8 addrspace(200)*)*) to void (i8 addrspace(200)*) addrspace(200)*), i8 addrspace(200)* getelementptr inbounds (%"struct.PR20227::A", %"struct.PR20227::A" addrspace(200)* @_ZGRN7PR202271aE_, i32 0, i32 0), i8 addrspace(200)* @__dso_handle) #2
+// CHECK:   %0 = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+// CHECK:   %1 = call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* %0, i64 ptrtoint (void (%"struct.PR20227::A" addrspace(200)*)* @_ZN7PR202271AD1Ev to i64))
+// CHECK:   %2 = bitcast i8 addrspace(200)* %1 to void (i8 addrspace(200)*) addrspace(200)*
+// CHECK:   %3 = call i32 @__cxa_atexit(void (i8 addrspace(200)*) addrspace(200)* %2, i8 addrspace(200)* getelementptr inbounds (%"struct.PR20227::A", %"struct.PR20227::A" addrspace(200)* @_ZGRN7PR202271aE_, i32 0, i32 0), i8 addrspace(200)* @__dso_handle) #2
 // CHECK:   store %"struct.PR20227::A" addrspace(200)* @_ZGRN7PR202271aE_, %"struct.PR20227::A" addrspace(200)* addrspace(200)* @_ZN7PR202271aE, align 32
 // CHECK:   ret void
 
+// CHECK: declare i32 @__cxa_atexit(void (i8 addrspace(200)*) addrspace(200)*, i8 addrspace(200)*, i8 addrspace(200)*) #2
 
 // CHECK: define internal void @__cxx_global_var_init.1() #0 {
-// CHECK:   call void @llvm.memset.p200i8.i64(i8 addrspace(200)* bitcast (%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_ to i8 addrspace(200)*), i8 0, i64 32, i32 32, i1 false)
-// CHECK:   call void @_ZN7PR202271CC1Ev(%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_) #2
-// CHECK:   %0 = call i32 @__cxa_atexit(void (i8 addrspace(200)*) addrspace(200)* addrspacecast (void (i8 addrspace(200)*)* bitcast (void (%"struct.PR20227::C" addrspace(200)*)* @_ZN7PR202271CD1Ev to void (i8 addrspace(200)*)*) to void (i8 addrspace(200)*) addrspace(200)*), i8 addrspace(200)* bitcast (%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_ to i8 addrspace(200)*), i8 addrspace(200)* @__dso_handle) #2
-// CHECK:   store %"struct.PR20227::B" addrspace(200)* getelementptr inbounds (%"struct.PR20227::C", %"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_, i32 0, i32 0), %"struct.PR20227::B" addrspace(200)* addrspace(200)* @_ZN7PR202271cE, align 32
-// CHECK:   ret void
+// CHECK:    call void @llvm.memset.p200i8.i64(i8 addrspace(200)* bitcast (%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_ to i8 addrspace(200)*), i8 0, i64 32, i32 32, i1 false)
+// CHECK:    call void @_ZN7PR202271CC1Ev(%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_) #2
+// CHECK:    %0 = call i8 addrspace(200)* @llvm.cheri.pcc.get()
+// CHECK:    %1 = call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* %0, i64 ptrtoint (void (%"struct.PR20227::C" addrspace(200)*)* @_ZN7PR202271CD1Ev to i64))
+// CHECK:    %2 = bitcast i8 addrspace(200)* %1 to void (i8 addrspace(200)*) addrspace(200)*
+// CHECK:    %3 = call i32 @__cxa_atexit(void (i8 addrspace(200)*) addrspace(200)* %2, i8 addrspace(200)* bitcast (%"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_ to i8 addrspace(200)*), i8 addrspace(200)* @__dso_handle) #2
+// CHECK:    store %"struct.PR20227::B" addrspace(200)* getelementptr inbounds (%"struct.PR20227::C", %"struct.PR20227::C" addrspace(200)* @_ZGRN7PR202271cE_, i32 0, i32 0), %"struct.PR20227::B" addrspace(200)* addrspace(200)* @_ZN7PR202271cE, align 32
+// CHECK:    ret void

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -322,6 +322,7 @@ NoPostBar = r"(?!(/|\\))"
 
 tool_patterns = [r"\bFileCheck\b",
                  r"\bc-index-test\b",
+                 r"\bllvm-objdump\b",
                  NoPreHyphenDot + r"\bclang-check\b" + NoPostHyphenDot,
                  NoPreHyphenDot + r"\bclang-format\b" + NoPostHyphenDot,
                  # FIXME: Some clang test uses opt?


### PR DESCRIPTION
This partially fixes #121 , however I am not yet using the tag bit to distinguish virtual from non-virtual member pointers. This would require further changes such as requiring non-zero initialization for null member function pointers if we no longer use the low bit of adj to indicate pointers being virtual.
Maybe we could use adj == -1 to indicate an invalid virtual function pointer?