### PR TITLE
MIPS N32 patch 3 (1,2,5 on llvm), pass ABI in triple

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -7734,10 +7734,22 @@ public:
         CapSize(-1) {
     TheCXXABI.set(TargetCXXABI::GenericMIPS);
 
-    setABI((getTriple().getArch() == llvm::Triple::mips ||
-            getTriple().getArch() == llvm::Triple::mipsel)
-               ? "o32"
-               : "n64");
+    if (getTriple().getEnvironment() == llvm::Triple::ABI32 ||
+        getTriple().getEnvironment() == llvm::Triple::GNUABI32 ||
+        getTriple().getEnvironment() == llvm::Triple::AndroidABI32)
+      setABI("o32");
+    else if (getTriple().getEnvironment() == llvm::Triple::ABIN32 ||
+        getTriple().getEnvironment() == llvm::Triple::GNUABIN32)
+      setABI("n32");
+    else if (getTriple().getEnvironment() == llvm::Triple::ABI64 ||
+             getTriple().getEnvironment() == llvm::Triple::GNUABI64 ||
+             getTriple().getEnvironment() == llvm::Triple::AndroidABI64)
+      setABI("n64");
+    else
+      setABI((getTriple().getArch() == llvm::Triple::mips ||
+              getTriple().getArch() == llvm::Triple::mipsel)
+                 ? "o32"
+                 : "n64");
 
     CPU = ABI == "o32" ? "mips32r2" : "mips64r2";
     if (IsCHERI) {
@@ -7792,17 +7804,20 @@ public:
     if (Name == "o32") {
       setO32ABITypes();
       ABI = Name;
+      setDataLayout();
       return true;
     }
 
     if (Name == "n32") {
       setN32ABITypes();
       ABI = Name;
+      setDataLayout();
       return true;
     }
     if (Name == "n64") {
       setN64ABITypes();
       ABI = Name;
+      setDataLayout();
       return true;
     }
     if (Name == "purecap") {

--- a/lib/Driver/ToolChains/Arch/Mips.cpp
+++ b/lib/Driver/ToolChains/Arch/Mips.cpp
@@ -32,10 +32,14 @@ void mips::getMipsCPUAndABI(const ArgList &Args, const llvm::Triple &Triple,
                             StringRef &CPUName, StringRef &ABIName) {
   const char *DefMips32CPU = "mips32r2";
   const char *DefMips64CPU = "mips64r2";
+#if CHERI_IS_64
+  const char *CHERICPU = "cheri64";
+#else
 #if CHERI_IS_128
   const char *CHERICPU = "cheri128";
 #else
   const char *CHERICPU = "cheri";
+#endif
 #endif
 
   // MIPS32r6 is the default for mips(el)?-img-linux-gnu and MIPS64r6 is the
@@ -138,9 +142,12 @@ void mips::getMipsCPUAndABI(const ArgList &Args, const llvm::Triple &Triple,
 
   // change CPU from cheri to cheri128 if -mllvm -cheri128 was passed
   if (CPUName == CHERICPU)
-    for (const Arg *A : Args.filtered(options::OPT_mllvm))
+    for (const Arg *A : Args.filtered(options::OPT_mllvm)) {
         if (StringRef(A->getValue(0)) == "-cheri128")
           CPUName = "cheri128";
+        if (StringRef(A->getValue(0)) == "-cheri64")
+          CPUName = "cheri64";
+    }
 
   // FIXME: Warn on inconsistent use of -march and -mabi.
 }

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -1485,6 +1485,18 @@ void Clang::AddMIPSTargetArgs(const ArgList &Args,
       CmdArgs.push_back("-cheri128");
     }
   }
+  if (CPUName == "cheri64" && getToolChain().getArch() == llvm::Triple::cheri) {
+    // Add -mllvm -cheri64 if -mcpu=cheri64 is passed and ensure that it is
+    // only passed once because otherwise the compilation will fail
+    bool HaveCHERI64Flag = false;
+    for (const Arg *A : Args.filtered(options::OPT_mllvm))
+      if (StringRef(A->getValue(0)) == "-cheri64")
+        HaveCHERI64Flag = true;
+    if (!HaveCHERI64Flag) {
+      CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back("-cheri64");
+    }
+  }
 }
 
 void Clang::AddPPCTargetArgs(const ArgList &Args,

--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -1408,12 +1408,12 @@ bool clang::driver::findMIPSMultilibs(const Driver &D,
 
   if (TargetTriple.getVendor() == llvm::Triple::MipsTechnologies &&
       TargetTriple.getOS() == llvm::Triple::Linux &&
-      TargetTriple.getEnvironment() == llvm::Triple::GNU)
+      TargetTriple.isGNUEnvironment())
     return findMipsMtiMultilibs(Flags, NonExistent, Result);
 
   if (TargetTriple.getVendor() == llvm::Triple::ImaginationTechnologies &&
       TargetTriple.getOS() == llvm::Triple::Linux &&
-      TargetTriple.getEnvironment() == llvm::Triple::GNU)
+      TargetTriple.isGNUEnvironment())
     return findMipsImgMultilibs(Flags, NonExistent, Result);
 
   if (findMipsCsMultilibs(Flags, NonExistent, Result))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2527,6 +2527,17 @@ static void ParseTargetArgs(TargetOptions &Opts, ArgList &Args,
   // Use the default target triple if unspecified.
   if (Opts.Triple.empty())
     Opts.Triple = llvm::sys::getDefaultTargetTriple();
+
+  // Modify the Triple and ABI according to the Triple and ABI.
+  llvm::Triple ABITriple;
+  StringRef ABIName;
+  std::tie(ABITriple, ABIName) =
+      llvm::Triple(Opts.Triple).getABIVariant(Opts.ABI);
+  if (ABITriple.getArch() == llvm::Triple::UnknownArch)
+    Diags.Report(diag::err_target_unknown_abi) << Opts.ABI;
+  Opts.Triple = ABITriple.str();
+  Opts.ABI = ABIName;
+
   Opts.OpenCLExtensionsAsWritten = Args.getAllArgValues(OPT_cl_ext_EQ);
 
   llvm::Triple T(Opts.Triple);


### PR DESCRIPTION
This is the clang side for Mips N32 support, also requires the LLVM pull request https://github.com/CTSRD-CHERI/llvm/pull/230


Commit message:

From https://reviews.llvm.org/D21070 :

Pass the ABI in the triple when appropriate (currently for MIPS) for
'clang -cc1' and 'clang -cc1as'

'clang -cc1' and 'clang -cc1as' will mutate the triple to account for
-target-abi if such a conversion is defined by Triple::getABIVariant().
Otherwise, the ABI will continue to be passed via
MCTargetOptions::ABIName.

Additionally, 'clang -cc1as' now applies the effect of -target-abi.
Previously it was ignored.

Patch by: Daniel Sanders