### PR TITLE
Add alignment builtins that also work for CHERI

### DIFF
--- a/include/clang/Basic/Builtins.def
+++ b/include/clang/Basic/Builtins.def
@@ -1363,6 +1363,19 @@ BUILTIN(__builtin_operator_new, "v*z", "c")
 BUILTIN(__builtin_operator_delete, "vv*", "n")
 BUILTIN(__builtin_char_memchr, "c*cC*iz", "n")
 
+
+// Alignment builtins (uses custom parsing to support pointers and capabilities)
+// Builtins to align a value to a specific number of bytes (undefined behaviour/error if the value is not a power of two)
+BUILTIN(__builtin_is_aligned, "bvC*z", "nct")
+BUILTIN(__builtin_align_up, "v*vC*z", "nct")
+BUILTIN(__builtin_align_down, "v*vC*z", "nct")
+// The same builtins but with the second argument as a power of two instead of an integer
+// undefined behaviour if the requested value is greater than the number of bits
+BUILTIN(__builtin_is_p2aligned, "bvC*z", "nct")
+BUILTIN(__builtin_p2align_up, "v*vC*z", "nct")
+BUILTIN(__builtin_p2align_down, "v*vC*z", "nct")
+
+
 // Memory capability builtins
 BUILTIN(__builtin_cheri_length_set, "v*mvC*mz", "nc")
 BUILTIN(__builtin_cheri_bounds_set, "v*mvC*mz", "nc")

--- a/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2686,6 +2686,13 @@ def err_alignment_not_power_of_two : Error<
 def err_alignment_dependent_typedef_name : Error<
   "requested alignment is dependent but declaration is not dependent">;
 
+def err_alignment_power_of_two_out_of_range : Error<
+  "requested power-of-two alignment %0 is not a value between %1 and %2">;
+def warn_alignment_builtin_useless : Warning<
+  "%select{aligning a value|checking whether a value is aligned}0 to 1 byte is"
+   " always %select{a noop|true}0">, InGroup<TautologicalCompare>;
+
+
 def err_attribute_aligned_too_great : Error<
   "requested alignment must be %0 bytes or smaller">;
 def warn_redeclaration_without_attribute_prev_attribute_ignored : Warning<

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -5860,6 +5860,7 @@ bool PointerExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
         return false;
       }
     }
+    // TODO: can we handle __builtin_/align_down/aligned_up/is_aligned here?
 
     // The offset must also have the correct alignment.
     if (OffsetResult.Offset.alignTo(Align) != OffsetResult.Offset) {
@@ -7619,6 +7620,31 @@ bool IntExprEvaluator::VisitCallExpr(const CallExpr *E) {
   return ExprEvaluatorBaseTy::VisitCallExpr(E);
 }
 
+static bool getBuiltinAlignArguments(const CallExpr *E, EvalInfo &Info,
+                                     bool IsPowerOfTwo, APSInt &Val,
+                                     APSInt &Alignment) {
+  if (!EvaluateInteger(E->getArg(0), Val, Info))
+    return false;
+  if (!EvaluateInteger(E->getArg(1), Alignment, Info))
+    return false;
+  if (Alignment < 0)
+    return false;
+  if (IsPowerOfTwo) {
+    if (Alignment > 63)
+      return false; // can't evaluate this
+    unsigned SetBit = Alignment.getZExtValue();
+    Alignment = APSInt(llvm::APInt::getOneBitSet(SetBit + 1, SetBit));
+  }
+  // XXXAR: can this ever happen? Will end up here even if Sema causes an error?
+  // I guess this additional check doesn't do any harm
+  if (!Alignment.isPowerOf2())
+    return false;
+  // ensure both values have the same bit width so that we don't assert later
+  Val = Val.zextOrSelf(Alignment.getBitWidth());
+  Alignment = Alignment.zextOrSelf(Val.getBitWidth());
+  return true;
+}
+
 bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
                                             unsigned BuiltinOp) {
   switch (unsigned BuiltinOp = E->getBuiltinCallee()) {
@@ -7656,6 +7682,36 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
     }
 
     llvm_unreachable("unexpected EvalMode");
+  }
+
+  case Builtin::BI__builtin_is_aligned:
+  case Builtin::BI__builtin_is_p2aligned: {
+    APSInt Val;
+    APSInt Alignment;
+    bool Pow2 = BuiltinOp == Builtin::BI__builtin_is_p2aligned;
+    if (!getBuiltinAlignArguments(E, Info, Pow2, Val, Alignment))
+      return false;
+    return Success((Val & (Alignment - 1)) == 0 ? 1 : 0, E);
+  }
+  case Builtin::BI__builtin_align_up:
+  case Builtin::BI__builtin_p2align_up: {
+    APSInt Val;
+    APSInt Alignment;
+    bool Pow2 = BuiltinOp == Builtin::BI__builtin_p2align_up;
+    if (!getBuiltinAlignArguments(E, Info, Pow2, Val, Alignment))
+      return false;
+    // #define roundup2(x, y) (((x)+((y)-1))&(~((y)-1)))
+    return Success((Val + (Alignment - 1)) & ~(Alignment - 1), E);
+  }
+  case Builtin::BI__builtin_align_down:
+  case Builtin::BI__builtin_p2align_down: {
+    APSInt Val;
+    APSInt Alignment;
+    bool Pow2 = BuiltinOp == Builtin::BI__builtin_p2align_down;
+    if (!getBuiltinAlignArguments(E, Info, Pow2, Val, Alignment))
+      return false;
+    // #define rounddown2(x, y) ((x)&(~((y)-1)))
+    return Success(Val & ~(Alignment - 1), E);
   }
 
   case Builtin::BI__builtin_bswap16:

--- a/lib/AST/ExprConstant.cpp
+++ b/lib/AST/ExprConstant.cpp
@@ -7623,9 +7623,9 @@ bool IntExprEvaluator::VisitCallExpr(const CallExpr *E) {
 static bool getBuiltinAlignArguments(const CallExpr *E, EvalInfo &Info,
                                      bool IsPowerOfTwo, APSInt &Val,
                                      APSInt &Alignment) {
-  if (!EvaluateInteger(E->getArg(0), Val, Info))
+  if (!E->getArg(0)->EvaluateAsInt(Val, Info.Ctx))
     return false;
-  if (!EvaluateInteger(E->getArg(1), Alignment, Info))
+  if (!E->getArg(1)->EvaluateAsInt(Alignment, Info.Ctx))
     return false;
   if (Alignment < 0)
     return false;

--- a/lib/CodeGen/BackendUtil.cpp
+++ b/lib/CodeGen/BackendUtil.cpp
@@ -540,6 +540,8 @@ void EmitAssemblyHelper::CreatePasses(legacy::PassManager &MPM,
                          addCHERICapFoldIntrinsicsPass);
   PMBuilder.addExtension(PassManagerBuilder::EP_ScalarOptimizerLate,
                          addCHERICapFoldIntrinsicsPass);
+  PMBuilder.addExtension(PassManagerBuilder::EP_OptimizerLast,
+                         addCHERICapFoldIntrinsicsPass);
 
   if (LangOpts.Sanitize.has(SanitizerKind::LocalBounds)) {
     PMBuilder.addExtension(PassManagerBuilder::EP_ScalarOptimizerLate,

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3381,6 +3381,8 @@ public:
 
   // Emit IR for __builtin_is_aligned/__builtin_is_p2aligned
   RValue EmitBuiltinIsAligned(const CallExpr *E, bool PowerOfTwo);
+  RValue EmitBuiltinAlignTo(const CallExpr *E, bool PowerOfTwo, bool AlignUp);
+
   llvm::Function *generateBuiltinOSLogHelperFunction(
       const analyze_os_log::OSLogBufferLayout &Layout,
       CharUnits BufferAlignment);

--- a/lib/CodeGen/CodeGenFunction.h
+++ b/lib/CodeGen/CodeGenFunction.h
@@ -3379,6 +3379,8 @@ public:
   /// Emit IR for __builtin_os_log_format.
   RValue emitBuiltinOSLogFormat(const CallExpr &E);
 
+  // Emit IR for __builtin_is_aligned/__builtin_is_p2aligned
+  RValue EmitBuiltinIsAligned(const CallExpr *E, bool PowerOfTwo);
   llvm::Function *generateBuiltinOSLogHelperFunction(
       const analyze_os_log::OSLogBufferLayout &Layout,
       CharUnits BufferAlignment);

--- a/test/CodeGen/CHERI/builtin-align.c
+++ b/test/CodeGen/CHERI/builtin-align.c
@@ -1,0 +1,59 @@
+// RUN: %cheri_cc1 -o - -O0 -emit-llvm %s | FileCheck %s -check-prefixes SLOW,BOTH
+// RUN: %cheri_cc1 -o - -O2 -emit-llvm %s | FileCheck %s -check-prefixes OPT,BOTH
+
+_Bool is_aligned(void *x) {
+  // BOTH-LABEL: is_aligned(
+  // BOTH:      [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // BOTH-NEXT: %set_bits = and i64 [[VAR]], 31
+  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // BOTH-NEXT: ret i1 %is_aligned
+  return __builtin_is_aligned(x, 32);
+}
+
+_Bool is_aligned2(void *x) {
+  // BOTH-LABEL: is_aligned2(
+  // BOTH:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // BOTH-NEXT: %set_bits = and i64 [[VAR]], 127
+  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // BOTH-NEXT: ret i1 %is_aligned
+  return __builtin_is_p2aligned(x, 7);
+}
+
+_Bool is_aligned3(void *x, int p2align) {
+  // BOTH-LABEL: is_aligned3(
+  // BOTH:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // SLOW-NEXT: %2 = load i32, i32* %p2align.addr, align 4
+  // SLOW-NEXT: %pow2 = zext i32 %2 to i64
+  // OPT-NEXT:  %pow2 = zext i32 %p2align to i64
+  // BOTH-NEXT: %alignment = shl i64 1, %pow2
+  // SLOW-NEXT: %mask = sub i64 %alignment, 1
+  // OPT-NEXT: %mask = add i64 %alignment, -1
+  // SLOW-NEXT: %set_bits = and i64 [[VAR]], %mask
+  // OPT-NEXT: %set_bits = and i64 %mask, [[VAR]]
+  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // BOTH-NEXT: ret i1 %is_aligned
+  return __builtin_is_p2aligned(x, p2align);
+}
+
+// Check that constants get folded
+_Bool opt_is_aligned1(void *x) {
+  // BOTH-LABEL: opt_is_aligned1(
+  // SLOW:   [[PHI:%.+]] = phi i1 [ false, %{{.+}} ], [ %{{.+}}, %{{.+}} ]
+  // SLOW: ret i1 [[PHI]]
+  // OPT: ret i1 true
+  return __builtin_is_p2aligned(x, 0) && __builtin_is_aligned(x, 1);
+}
+
+_Bool opt_is_aligned2() {
+  // This expression gets folded even at -O0:
+  // BOTH-LABEL: opt_is_aligned2(
+  // BOTH: ret i1 false
+  return __builtin_is_p2aligned(7, 3);
+}
+
+_Bool opt_is_aligned3() {
+  // This expression gets folded even at -O0:
+  // BOTH-LABEL: opt_is_aligned3(
+  // BOTH: ret i1 true
+  return __builtin_is_aligned(1024, 512);
+}

--- a/test/CodeGen/CHERI/builtin-align.c
+++ b/test/CodeGen/CHERI/builtin-align.c
@@ -1,59 +1,194 @@
-// RUN: %cheri_cc1 -o - -O0 -emit-llvm %s | FileCheck %s -check-prefixes SLOW,BOTH
-// RUN: %cheri_cc1 -o - -O2 -emit-llvm %s | FileCheck %s -check-prefixes OPT,BOTH
+// RUN: %cheri_cc1 -DTEST_PTR -Wno-tautological-compare -o - -O0 -emit-llvm %s
+// RUN: %cheri_cc1 -DTEST_LONG -Wno-tautological-compare -o - -O0 -emit-llvm %s
+// RUN: %cheri_cc1 -DTEST_PTR -Wno-tautological-compare -o - -O0 -emit-llvm %s |  FileCheck %s -check-prefixes CHECK,PTR,SLOW,PTR-SLOW -enable-var-scope
+// RUN: %cheri_cc1 -DTEST_PTR -Wno-tautological-compare -o - -O2 -emit-llvm %s |  FileCheck %s -check-prefixes CHECK,PTR,OPT,PTR-OPT  -enable-var-scope
+// RUN: %cheri_cc1 -DTEST_LONG -Wno-tautological-compare -o - -O0 -emit-llvm %s | FileCheck %s -check-prefixes CHECK,LONG,SLOW,LONG-SLOW  -enable-var-scope
+// RUN: %cheri_cc1 -DTEST_LONG -Wno-tautological-compare -o - -O2 -emit-llvm %s | FileCheck %s -check-prefixes CHECK,LONG,OPT,LONG-OPT  -enable-var-scope
 
-_Bool is_aligned(void *x) {
-  // BOTH-LABEL: is_aligned(
-  // BOTH:      [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
-  // BOTH-NEXT: %set_bits = and i64 [[VAR]], 31
-  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
-  // BOTH-NEXT: ret i1 %is_aligned
-  return __builtin_is_aligned(x, 32);
+// TODO: tests for the CHERI case
+#ifdef TEST_PTR
+#define TYPE void *
+#elif defined(TEST_LONG)
+#define TYPE long
+#else
+#error MISSING TYPE
+#endif
+
+// Check that initializers are constant
+// XXXAR: Note: they are evaluated by IntExprEvaluator and not CodeGen so work
+// even if the Values emitted by CodeGen are wrong (which they initially were)
+_Bool global_constant = __builtin_is_aligned(1024, 512);
+_Bool global_constant2 = __builtin_is_p2aligned(1024, 11);
+// SLOW: @global_constant = global i8 1, align 1
+// SLOW: @global_constant2 = global i8 0, align 1
+int a1 = __builtin_align_down(1023, 32);
+int a2 = __builtin_align_up(1023, 32);
+int a3 = __builtin_p2align_down(1023, 1);
+int a4 = __builtin_p2align_up(1, 6);
+// SLOW: @a1 = global i32 992, align 4
+// SLOW: @a2 = global i32 1024, align 4
+// SLOW: @a3 = global i32 1022, align 4
+// SLOW: @a4 = global i32 64, align 4
+
+TYPE get_type(void) {
+  // CHECK: define{{( noalias)?}} [[$TYPE:.+]] @get_type()
+  return (TYPE)0;
 }
 
-_Bool is_aligned2(void *x) {
-  // BOTH-LABEL: is_aligned2(
-  // BOTH:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
-  // BOTH-NEXT: %set_bits = and i64 [[VAR]], 127
-  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
-  // BOTH-NEXT: ret i1 %is_aligned
+_Bool is_aligned(TYPE ptr, unsigned align) {
+  // TODO: should we allow non-constant values and just say not passing a power-of-two is undefined?
+  // CHECK-LABEL: is_aligned(
+  // PTR:      [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW:  [[VAR:%.+]] = load i64
+  // SLOW: %set_bits = and i64 [[VAR]], 31
+  // SLOW-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // SLOW-NEXT: ret i1 %is_aligned
+  return __builtin_is_aligned(ptr, 32);
+}
+
+_Bool is_p2aligned(TYPE ptr, int p2align) {
+  // CHECK-LABEL: is_p2aligned(
+  // PTR:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW:  [[VAR:%.+]] = load i64
+  // SLOW-NEXT: [[P2VAL:%.+]] = load i32, i32* %p2align.addr, align 4
+  // SLOW-NEXT: %pow2 = zext i32 [[P2VAL]] to i64
+  // SLOW-NEXT: %alignment = shl i64 1, %pow2
+  // SLOW-NEXT: %mask = sub i64 %alignment, 1
+  // SLOW-NEXT: %set_bits = and i64 [[VAR]], %mask
+  // SLOW-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // SLOW-NEXT: ret i1 %is_aligned
+  return __builtin_is_p2aligned(ptr, p2align);
+}
+
+TYPE align_up(TYPE ptr, unsigned align) {
+  // TODO: should we allow non-constant values and just say not passing a power-of-two is undefined?
+  // CHECK-LABEL: @align_up(
+  // PTR:       [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW: [[VAR:%.+]] = load i64
+  // SLOW:      [[VAR2:%.+]] = add i64 [[VAR]], 31
+  // SLOW:      [[MASKED:%.+]] = and i64 [[VAR2]], -32
+  // PTR:       %aligned_result = inttoptr i64 [[MASKED:%.+]] to i8*
+  // PTR:       ret [[$TYPE]] %aligned_result
+  // LONG-SLOW: ret i64 [[MASKED]]
+  return __builtin_align_up(ptr, 32);
+}
+
+TYPE p2align_up(TYPE ptr, unsigned p2align) {
+  // CHECK-LABEL: @p2align_up(
+  // PTR:       [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW: [[VAR:%.+]] = load i64
+  // SLOW:      %alignment = shl i64 1, %pow2
+  // SLOW:      %mask = sub i64 %alignment, 1
+  // SLOW:      [[VAR_TMP:%.+]] = add i64 [[VAR]], %mask
+  // SLOW:      %negated_mask = xor i64 %mask, -1
+  // SLOW:      [[MASKED:%.+]] = and i64 [[VAR_TMP:%.+]], %negated_mask
+  // PTR:       %aligned_result = inttoptr i64 [[MASKED:%.+]] to i8*
+  // PTR:       ret [[$TYPE]] %aligned_result
+  // LONG-SLOW: ret i64 [[MASKED]]
+  return __builtin_p2align_up(ptr, p2align);
+}
+
+TYPE align_down(TYPE ptr, unsigned align) {
+  // TODO: should we allow non-constant values and just say not passing a power-of-two is undefined?
+  // CHECK-LABEL: @align_down(
+  // PTR:       [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW: [[VAR:%.+]] = load i64
+  // SLOW:      [[MASKED:%.+]] = and i64 [[VAR]], -32
+  // PTR:       %aligned_result = inttoptr i64 [[MASKED:%.+]] to i8*
+  // PTR:       ret [[$TYPE]] %aligned_result
+  // LONG-SLOW: ret i64 [[MASKED]]
+  return __builtin_align_down(ptr, 32);
+}
+
+TYPE p2align_down(TYPE ptr, unsigned p2align) {
+  // CHECK-LABEL: @p2align_down(
+  // PTR:       [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW: [[VAR:%.+]] = load i64
+  // SLOW:      %alignment = shl i64 1, %pow2
+  // SLOW:      %mask = sub i64 %alignment, 1
+  // SLOW:      %negated_mask = xor i64 %mask, -1
+  // SLOW:      [[MASKED:%.+]] = and i64 [[VAR_TMP:%.+]], %negated_mask
+  // PTR:       %aligned_result = inttoptr i64 [[MASKED:%.+]] to i8*
+  // PTR:       ret [[$TYPE]] %aligned_result
+  // LONG-SLOW: ret i64 [[MASKED]]
+  return __builtin_p2align_down(ptr, p2align);
+}
+
+// Check that the inliner removes these constant calls at -O2 but not -O0:
+_Bool inline_is_aligned(void) {
+  // CHECK-LABEL: @inline_is_aligned(
+  // SLOW: call zeroext i1 @is_aligned([[$TYPE]]{{.+}}100{{.*}}, i32 signext 32)
+  // OPT: ret i1 false
+  return is_aligned((TYPE)100, 32);
+}
+
+_Bool inline_is_p2aligned(void) {
+  // CHECK-LABEL: @inline_is_p2aligned(
+  // SLOW: call zeroext i1 @is_p2aligned([[$TYPE]]{{.+}}128{{.*}}, i32 signext 6)
+  // OPT: ret i1 true
+  return is_p2aligned((TYPE)128, 6);
+}
+
+TYPE inline_align_down(void) {
+  // CHECK-LABEL: @inline_align_down(
+  // SLOW: call [[$TYPE]] @align_down({{.+}}100{{.*}}, i32 signext 32)
+  // LONG-OPT: ret i64 96
+  return align_down((TYPE)100, 32);
+}
+
+TYPE inline_p2align_down(void) {
+  // CHECK-LABEL: @inline_p2align_down(
+  // SLOW: call [[$TYPE]] @p2align_down({{.+}}100{{.*}}, i32 signext 10)
+  // LONG-OPT: ret i64 0
+  return p2align_down((TYPE)100, 10);
+}
+
+TYPE inline_align_up(void) {
+  // CHECK-LABEL: @inline_align_up(
+  // SLOW: call [[$TYPE]] @align_up({{.+}}100{{.*}}, i32 signext 32)
+  // LONG-OPT: ret i64 128
+  return align_up((TYPE)100, 32);
+}
+
+TYPE inline_p2align_up(void) {
+  // CHECK-LABEL: @inline_p2align_up(
+  // SLOW: call [[$TYPE]] @p2align_up({{.+}}100{{.*}}, i32 signext 10)
+  // LONG-OPT: ret i64 1024
+  return p2align_up((TYPE)100, 10);
+}
+
+// XXX: original tests, can probably remove
+
+// Check that some constants get folded for __is_aligned
+_Bool opt_is_aligned(TYPE x) {
+  // CHECK-LABEL: @opt_is_aligned(
+  // LONG-OPT-SAME: i64 signext [[VAR:%.+]])
+  // PTR:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
+  // LONG-SLOW:  [[VAR:%.+]] = load i64
+  // CHECK: %set_bits = and i64 [[VAR]], 127
+  // CHECK-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
+  // CHECK-NEXT: ret i1 %is_aligned
   return __builtin_is_p2aligned(x, 7);
 }
 
-_Bool is_aligned3(void *x, int p2align) {
-  // BOTH-LABEL: is_aligned3(
-  // BOTH:     [[VAR:%.+]] = ptrtoint i8* %{{.+}} to i64
-  // SLOW-NEXT: %2 = load i32, i32* %p2align.addr, align 4
-  // SLOW-NEXT: %pow2 = zext i32 %2 to i64
-  // OPT-NEXT:  %pow2 = zext i32 %p2align to i64
-  // BOTH-NEXT: %alignment = shl i64 1, %pow2
-  // SLOW-NEXT: %mask = sub i64 %alignment, 1
-  // OPT-NEXT: %mask = add i64 %alignment, -1
-  // SLOW-NEXT: %set_bits = and i64 [[VAR]], %mask
-  // OPT-NEXT: %set_bits = and i64 %mask, [[VAR]]
-  // BOTH-NEXT: %is_aligned = icmp eq i64 %set_bits, 0
-  // BOTH-NEXT: ret i1 %is_aligned
-  return __builtin_is_p2aligned(x, p2align);
-}
-
-// Check that constants get folded
-_Bool opt_is_aligned1(void *x) {
-  // BOTH-LABEL: opt_is_aligned1(
-  // SLOW:   [[PHI:%.+]] = phi i1 [ false, %{{.+}} ], [ %{{.+}}, %{{.+}} ]
+_Bool opt_is_aligned1(TYPE x) {
+  // CHECK-LABEL: @opt_is_aligned1(
+  // SLOW: [[PHI:%.+]] = phi i1 [ false, %{{.+}} ], [ %{{.+}}, %{{.+}} ]
   // SLOW: ret i1 [[PHI]]
-  // OPT: ret i1 true
+  // OPT:  ret i1 true
   return __builtin_is_p2aligned(x, 0) && __builtin_is_aligned(x, 1);
 }
 
 _Bool opt_is_aligned2() {
   // This expression gets folded even at -O0:
-  // BOTH-LABEL: opt_is_aligned2(
-  // BOTH: ret i1 false
+  // CHECK-LABEL: @opt_is_aligned2(
+  // CHECK: ret i1 false
   return __builtin_is_p2aligned(7, 3);
 }
 
 _Bool opt_is_aligned3() {
   // This expression gets folded even at -O0:
-  // BOTH-LABEL: opt_is_aligned3(
-  // BOTH: ret i1 true
+  // CHECK-LABEL: @opt_is_aligned3(
+  // CHECK: ret i1 true
   return __builtin_is_aligned(1024, 512);
 }

--- a/test/CodeGen/CHERI/uintcap-add.c
+++ b/test/CodeGen/CHERI/uintcap-add.c
@@ -1,0 +1,19 @@
+// RUN: %cheri_cc1 -o - -O2 -emit-llvm %s | FileCheck %s
+
+void* __capability add_cap(void) {
+  char* __capability cap = (char* __capability)100;
+  cap += 10;
+  return cap + 914;
+  // This can return a valid tagged capability:
+  // CHECK-LABEL: @add_cap()
+  // CHECK: ret i8 addrspace(200)* inttoptr (i64 1024 to i8 addrspace(200)*)
+}
+
+__uintcap_t add_uintcap_t(void) {
+  __uintcap_t cap = (__uintcap_t)100;
+  cap += 10;
+  return cap + 914;
+  // But this always returns a untagged capability with offset 1024
+  // CHECK-LABEL: @add_uintcap_t()
+  // CHECK: tail call i8 addrspace(200)* @llvm.cheri.cap.offset.set(i8 addrspace(200)* null, i64 1024)
+}

--- a/test/CodeGenCXX/cheri/builtin-align-cpp-crash.cpp
+++ b/test/CodeGenCXX/cheri/builtin-align-cpp-crash.cpp
@@ -1,0 +1,5 @@
+// RUN: %cheri_purecap_cc1 -o - -O0 -emit-llvm  %s
+// Found while trying to use the builtin in QtBase
+void a(char* c, int b) {
+  __builtin_p2align_down(c, b);
+}

--- a/test/CodeGenOpenCL/convergent.cl
+++ b/test/CodeGenOpenCL/convergent.cl
@@ -130,5 +130,6 @@ void test_not_unroll() {
 // CHECK: attributes #1 = { {{[^}]*}}convergent{{[^}]*}} }
 // CHECK: attributes #2 = { {{[^}]*}}convergent{{[^}]*}} }
 // CHECK: attributes #3 = { {{[^}]*}}convergent noduplicate{{[^}]*}} }
-// CHECK: attributes #4 = { {{[^}]*}}convergent{{[^}]*}} }
-// CHECK: attributes #5 = { {{[^}]*}}convergent noduplicate{{[^}]*}} }
+// FIXME: for some reason the CHERI instriniscs are added to the module and then the attribute here is #5 instead of #4
+// CHECK: attributes #5 = { {{[^}]*}}convergent{{[^}]*}} }
+// CHECK: attributes #6 = { {{[^}]*}}convergent noduplicate{{[^}]*}} }

--- a/test/Sema/cheri/builtin-align.c
+++ b/test/Sema/cheri/builtin-align.c
@@ -1,0 +1,161 @@
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_is_p2aligned -DRETURNS_BOOL=1 -DPOW2=1 %s -fsyntax-only -verify -pedantic
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_p2align_up   -DRETURNS_BOOL=0 -DPOW2=1 %s -fsyntax-only -verify -pedantic
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_p2align_down -DRETURNS_BOOL=0 -DPOW2=1 %s -fsyntax-only -verify -pedantic
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_is_aligned   -DRETURNS_BOOL=1 -DPOW2=0 %s -fsyntax-only -verify -pedantic
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_align_up     -DRETURNS_BOOL=0 -DPOW2=0 %s -fsyntax-only -verify -pedantic
+// RUN: %cheri_cc1 -DALIGN_BUILTIN=__builtin_align_down   -DRETURNS_BOOL=0 -DPOW2=0 %s -fsyntax-only -verify -pedantic
+
+struct Aggregate {
+  int i;
+  int j;
+};
+enum Enum { EnumValue1,
+            EnumValue2 };
+typedef __SIZE_TYPE__ size_t;
+
+void test_parameter_types(char *ptr, size_t size) {
+  struct Aggregate agg;
+  enum Enum e = EnumValue2;
+  _Bool b = 0;
+
+  // first parameter can be any pointer or integer type:
+  (void)ALIGN_BUILTIN(ptr, 4);
+  (void)ALIGN_BUILTIN(size, 2);
+  (void)ALIGN_BUILTIN(12345, 2);
+  (void)ALIGN_BUILTIN(agg, 2);    // expected-error {{operand of type 'struct Aggregate' where arithmetic or pointer type is required}}
+  (void)ALIGN_BUILTIN(e, 2);      // expected-error {{operand of type 'enum Enum' where arithmetic or pointer type is required}}
+  (void)ALIGN_BUILTIN(b, 2);      // expected-error {{operand of type '_Bool' where arithmetic or pointer type is required}}
+  (void)ALIGN_BUILTIN((int)e, 2); // but with a cast it is fine
+  (void)ALIGN_BUILTIN((int)b, 2); // but with a cast it is fine
+
+  // second parameter doesn't have to be a constant for power of two versions:
+#if POW2
+  // second parameter must be an integer type (but not enum or _Bool)
+  (void)ALIGN_BUILTIN(ptr, size);
+  (void)ALIGN_BUILTIN(ptr, ptr);    // expected-error {{used type 'char *' where integer is required}}
+  (void)ALIGN_BUILTIN(ptr, agg);    // expected-error {{used type 'struct Aggregate' where integer is required}}
+  (void)ALIGN_BUILTIN(ptr, b);      // expected-error {{used type '_Bool' where integer is required}}
+  (void)ALIGN_BUILTIN(ptr, e);      // expected-error {{used type 'enum Enum' where integer is required}}
+  (void)ALIGN_BUILTIN(ptr, (int)e); // but with a cast it is fine
+  (void)ALIGN_BUILTIN(ptr, (int)b); // but with a cast it is fine
+
+  (void)ALIGN_BUILTIN(ptr, size);
+  (void)ALIGN_BUILTIN(size, size);
+#else
+  (void)ALIGN_BUILTIN(ptr, (_Bool)1);     // expected-error {{used type '_Bool' where integer is required}}
+  (void)ALIGN_BUILTIN(ptr, (enum Enum)4); // expected-error {{used type 'enum Enum' where integer is required}}
+#endif
+}
+
+void test_return_type(void *ptr, int i, long l, __uintcap_t uintcap, void *__capability cap) {
+  __extension__ typedef typeof(ALIGN_BUILTIN(ptr, 4)) result_type_ptr;
+  __extension__ typedef typeof(ALIGN_BUILTIN(i, 4)) result_type_int;
+  __extension__ typedef typeof(ALIGN_BUILTIN(l, 4)) result_type_long;
+  __extension__ typedef typeof(ALIGN_BUILTIN(uintcap, 4)) result_type_uintcap;
+  __extension__ typedef typeof(ALIGN_BUILTIN(cap, 4)) result_type_cap;
+#if RETURNS_BOOL
+  _Static_assert(__builtin_types_compatible_p(_Bool, result_type_ptr), "Should return bool");
+  _Static_assert(__builtin_types_compatible_p(_Bool, result_type_int), "Should return bool");
+  _Static_assert(__builtin_types_compatible_p(_Bool, result_type_long), "Should return bool");
+  _Static_assert(__builtin_types_compatible_p(_Bool, result_type_uintcap), "Should return bool");
+  _Static_assert(__builtin_types_compatible_p(_Bool, result_type_cap), "Should return bool");
+#else
+  _Static_assert(__builtin_types_compatible_p(void *, result_type_ptr), "Should return ");
+  _Static_assert(__builtin_types_compatible_p(int, result_type_int), "Should return int");
+  _Static_assert(__builtin_types_compatible_p(long, result_type_long), "Should return long");
+  _Static_assert(__builtin_types_compatible_p(__uintcap_t, result_type_uintcap), "Should return uintcap_t");
+  _Static_assert(__builtin_types_compatible_p(void *__capability, result_type_cap), "Should return capability");
+#endif
+}
+
+void test_cheri_parameter_types(void *__capability cap, __uintcap_t uintcap, __intcap_t intcap) {
+  // capabilities, uintcap_t and incap_t can also be aligned:
+  (void)ALIGN_BUILTIN(cap, 4);     // not strictly an integer type but should be allowed too
+  (void)ALIGN_BUILTIN(uintcap, 4); // not strictly an integer type but can also be aligned up/down
+  (void)ALIGN_BUILTIN(intcap, 4);  // not strictly an integer type but can also be aligned up/down
+
+  (void)ALIGN_BUILTIN(cap, cap); // expected-error{{used type 'void * __capability' where integer is required}}}
+  // For (u)intptr_t compatibility we also allow __uintcap_t and __intcap_t as the aligment parameter type
+  (void)ALIGN_BUILTIN(cap, (__uintcap_t)2); // not strictly an integer type but should be allowed as alignment value
+  (void)ALIGN_BUILTIN(cap, (__intcap_t)2);  // not strictly an integer type but should be allowed as alignment value
+#if POW2
+  (void)ALIGN_BUILTIN(cap, uintcap); // not strictly an integer type but should be allowed as alignment value
+  (void)ALIGN_BUILTIN(cap, intcap);  // not strictly an integer type but should be allowed as alignment value
+#endif
+}
+
+#if POW2
+void test_p2_range(char *ptr, void *__capability cap, size_t align) {
+  (void)ALIGN_BUILTIN(ptr, 65); // expected-error {{requested power-of-two alignment 65 is not a value between 0 and 63}}
+  int x = 1;
+  (void)ALIGN_BUILTIN(x, 32); // expected-error {{requested power-of-two alignment 32 is not a value between 0 and 31}}
+  (void)ALIGN_BUILTIN(x, 0);
+#if RETURNS_BOOL
+  // expected-warning@-2 {{checking whether a value is aligned to 1 byte is always true}}
+#else
+  // expected-warning@-4 {{aligning a value to 1 byte is always a noop}}
+#endif
+  (void)ALIGN_BUILTIN(x, -2); // expected-error {{requested power-of-two alignment -2 is not a value between 0 and 31}}
+
+  char c = ' ';
+  (void)ALIGN_BUILTIN(c, -1); // expected-error {{requested power-of-two alignment -1 is not a value between 0 and 7}}
+  (void)ALIGN_BUILTIN(c, 8);  // expected-error {{requested power-of-two alignment 8 is not a value between 0 and 7}}
+
+  // CHERI specific checks:
+  // The range should still be 1 to 63 and not 127/255
+  (void)ALIGN_BUILTIN(cap, -1); // expected-error {{requested power-of-two alignment -1 is not a value between 0 and 63}}
+  (void)ALIGN_BUILTIN(cap, 65); // expected-error {{requested power-of-two alignment 65 is not a value between 0 and 63}}
+  __uintcap_t uintcap = 3;
+  __intcap_t intcap = 4;
+  (void)ALIGN_BUILTIN(cap, uintcap); // not strictly an integer type but should be fine too
+  (void)ALIGN_BUILTIN(cap, intcap);  // not strictly an integer type but should be fine too
+
+  // check that we get the range right for __uintcap_t and __intcap_t
+  (void)ALIGN_BUILTIN(uintcap, 64); // expected-error {{requested power-of-two alignment 64 is not a value between 0 and 63}}
+  (void)ALIGN_BUILTIN(intcap, -5);  // expected-error {{requested power-of-two alignment -5 is not a value between 0 and 63}}
+}
+#else
+void test_non_p2_values(char *ptr, void *__capability cap, size_t align) {
+  int x = 1;
+  (void)ALIGN_BUILTIN(ptr, 2);
+  (void)ALIGN_BUILTIN(cap, 1024);
+  (void)ALIGN_BUILTIN(x, 32);
+
+  (void)ALIGN_BUILTIN(ptr, 0); // expected-error {{requested alignment must be 1 or greater}}
+  (void)ALIGN_BUILTIN(ptr, 1);
+#if RETURNS_BOOL
+  // expected-warning@-2 {{checking whether a value is aligned to 1 byte is always true}}
+#else
+  // expected-warning@-4 {{aligning a value to 1 byte is always a noop}}
+#endif
+  (void)ALIGN_BUILTIN(ptr, 3); // expected-error {{requested alignment is not a power of 2}}
+  (void)ALIGN_BUILTIN(x, 7);   // expected-error {{requested alignment is not a power of 2}}
+
+  // check the maximum range for smaller types:
+  __UINT8_TYPE__ c = ' ';
+
+  (void)ALIGN_BUILTIN(c, 128);        // this is fine
+  (void)ALIGN_BUILTIN(c, 256);        // expected-error {{requested alignment must be 128 or smaller}}
+  (void)ALIGN_BUILTIN(x, 1ULL << 31); // this is also fine
+  (void)ALIGN_BUILTIN(x, 1LL << 31);  // this is also fine
+  __INT32_TYPE__ i32 = 3;
+  __UINT32_TYPE__ u32 = 3;
+  // Maximum is the same for int32 and uint32
+  // XXXAR: should we differentiate?
+  (void)ALIGN_BUILTIN(i32, 1ULL << 32); // expected-error {{requested alignment must be 2147483648 or smaller}}
+  (void)ALIGN_BUILTIN(u32, 1ULL << 32); // expected-error {{requested alignment must be 2147483648 or smaller}}
+
+  // XXXAR: for now we only allow integer constant expressions
+  (void)ALIGN_BUILTIN(ptr, align);   // expected-error {{expression is not an integer constant}}
+  (void)ALIGN_BUILTIN(align, align); // expected-error {{expression is not an integer constant}}
+
+  // CHERI specific checks:
+  // The range should still be 1 to 63 and not 127/255
+  // TODO: can I generate a power of two bigger than 1 << 63? __int128_type?
+  __uintcap_t uintcap = 3;
+  __intcap_t intcap = 4;
+  (void)ALIGN_BUILTIN(cap, align);     // expected-error {{expression is not an integer constant}}
+  (void)ALIGN_BUILTIN(uintcap, align); // expected-error {{expression is not an integer constant}}
+  (void)ALIGN_BUILTIN(intcap, align);  // expected-error {{expression is not an integer constant}}
+}
+#endif

--- a/test/Sema/cheri/builtin-align.c
+++ b/test/Sema/cheri/builtin-align.c
@@ -161,7 +161,7 @@ void test_non_p2_values(char *ptr, void *__capability cap, size_t align) {
 #endif
 
 // check that it can be used in constant expressions
-void constant_expression(void) {
+void constant_expression(int x) {
   _Static_assert(__builtin_is_aligned(1024, 512), "");
   _Static_assert(!__builtin_is_aligned(256, 512ULL), "");
   _Static_assert(__builtin_align_up(33, 32) == 64, "");
@@ -172,4 +172,21 @@ void constant_expression(void) {
   _Static_assert(__builtin_is_p2aligned(8, 3), "");
   _Static_assert(__builtin_p2align_up(33, 5) == 64, "");
   _Static_assert(__builtin_p2align_down(33, 5) == 32, "");
+
+  // but not if one of the arguments isn't constant
+  _Static_assert(ALIGN_BUILTIN(33, x) != 100, "");
+#if POW2
+  // expected-error@-2 {{static_assert expression is not an integral constant expression}}
+#else
+  // expected-error@-4 {{expression is not an integer constant expression}}
+#endif
+  _Static_assert(ALIGN_BUILTIN(x, 4) != 100, ""); // expected-error {{static_assert expression is not an integral constant expression}}
 }
+
+int global1 = __builtin_align_down(33, 8);
+int global2 = __builtin_align_up(33, 8);
+_Bool global3 = __builtin_is_aligned(33, 8);
+
+int global4 = __builtin_p2align_down(33, 8);
+int global5 = __builtin_p2align_up(33, 8);
+_Bool global6 = __builtin_is_p2aligned(33, 8);

--- a/test/Sema/cheri/builtin-align.c
+++ b/test/Sema/cheri/builtin-align.c
@@ -159,3 +159,17 @@ void test_non_p2_values(char *ptr, void *__capability cap, size_t align) {
   (void)ALIGN_BUILTIN(intcap, align);  // expected-error {{expression is not an integer constant}}
 }
 #endif
+
+// check that it can be used in constant expressions
+void constant_expression(void) {
+  _Static_assert(__builtin_is_aligned(1024, 512), "");
+  _Static_assert(!__builtin_is_aligned(256, 512ULL), "");
+  _Static_assert(__builtin_align_up(33, 32) == 64, "");
+  _Static_assert(__builtin_align_down(33, 32) == 32, "");
+
+  _Static_assert(__builtin_is_p2aligned(1024, 9), "");
+  _Static_assert(!__builtin_is_p2aligned(3, 2), "");
+  _Static_assert(__builtin_is_p2aligned(8, 3), "");
+  _Static_assert(__builtin_p2align_up(33, 5) == 64, "");
+  _Static_assert(__builtin_p2align_down(33, 5) == 32, "");
+}


### PR DESCRIPTION
This adds `__builtin_is_aligned(ptr, align)`, `__builtin_align_up(ptr, align)`,  `__builtin_align_down(ptr, align)`. I also added builtins that take a powers of two exponent instead an alignment byte value.
They work on pointers, integers and capabilities and always return the same type as the first argument. For integer values they perform masking of the integer value and a cast back to a pointer.
For CHERI they compute the difference to the next aligned value and then use a CIncOffset to align the value.

Currently the non-power-of-two versions of the builtins only take integer constants whereas the p2 versions accept any value. After implementing the test cases I feel like it is probably silly to only allow constants in order to check that they are powers-of-two. Should I change it to allow any value as an argument and just garbage if a value that is not a power of two is passed. Maybe this should be checked this with a ubsan checker at runtime instead?