### PR TITLE
Add -cheri-cap-table-abi and -mxcaptable options.

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -259,6 +259,10 @@ def cheri_cap_table : Flag<["-"], "cheri-cap-table">, Flags<[DriverOption]>, Gro
   HelpText<"Enable support for loading globals via a capability table">;
 def no_cheri_cap_table : Flag<["-"], "no-cheri-cap-table">, Flags<[DriverOption]>, Group<cheri_Group>,
   HelpText<"Disable support for the cheri cap table and emit legacy global loads">;
+def cheri_cap_table_abi : Joined<["-"], "cheri-cap-table-abi=">, Group<cheri_Group>,
+  HelpText<"CHERI cap table ABI to use">;
+def cheri_large_cap_table : Flag<["-"], "mxcaptable">, Flags<[DriverOption]> Group<cheri_Group>,
+  HelpText<"Use large immediates to index the cap table">;
 
 def external_capsizefix : Flag<["-"], "external-capsizefix">, Flags<[CC1Option]>,
   Group<cheri_Group>, HelpText<"Use the external capsizefix tool instead of relying on the linker (deprecated)">;

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -1670,6 +1670,16 @@ void Clang::AddMIPSTargetArgs(const ArgList &Args,
   CmdArgs.push_back("-mllvm");
   CmdArgs.push_back(EnableCapTable ? "-cheri-cap-table=true"
                                    : "-cheri-cap-table=false");
+  if (Arg *A = Args.getLastArg(options::OPT_cheri_cap_table_abi)) {
+      StringRef v = A->getValue();
+      CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back(Args.MakeArgString("-cheri-cap-table-abi=" + v));
+      if (Args.hasFlag(options::OPT_cheri_large_cap_table)) {
+	  CmdArgs.push_back("-mllvm");
+	  CmdArgs.push_back("-mxcaptable");
+      }
+      A->claim();
+  }
 }
 
 void Clang::AddPPCTargetArgs(const ArgList &Args,


### PR DESCRIPTION
Add two options to the clang driver that set the corresponding LLVM options for controlling the cap table ABI and enabling the large cap table.